### PR TITLE
Version 1.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,23 @@
+## [1.0.3](https://github.com/HDB-Li/LLDebugTool/releases/tag/1.0.3) (05/31/2018)
+
+Fix some leaks.
+
+- Update
+
+    - LLDebugTool.h (Add annotation.)
+    - LLAppHelper (Forget call CFRelease.)
+    - LLURLProtocol (Manually release NSURLSession, Because the delegate of NSURLSession causes circular references.)
+    - NSURLSessionConfiguration+LLSwizzling (Add ephemeralSessionConfiguration.)
+    - LLSandboxModel (Call copy method.)
+    - LLBaseModel (Forget call free.)
+    - LLBaseViewController / LLFilterOtherView (Fix analyze warning.)
+    - LLTool / LLNetworkContentVC (Uncoupled code.)
+
+- Just For Demo
+
+    - NetTool (Use URLSession in a singleton.)
+    - ViewController (Fix a circular reference.)
+    
 ## [1.0.2](https://github.com/HDB-Li/LLDebugTool/releases/tag/1.0.2) (05/21/2018)
 
 * Fix the side gesture recognizer bug when pop.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,22 +2,18 @@
 
 Fix some leaks.
 
-- Update
+#### Update
 
-    - LLDebugTool.h (Add annotation.)
-    - LLAppHelper (Forget call CFRelease.)
-    - LLURLProtocol (Manually release NSURLSession, Because the delegate of NSURLSession causes circular references.)
-    - NSURLSessionConfiguration+LLSwizzling (Add ephemeralSessionConfiguration.)
-    - LLSandboxModel (Call copy method.)
-    - LLBaseModel (Forget call free.)
-    - LLBaseViewController / LLFilterOtherView (Fix analyze warning.)
-    - LLTool / LLNetworkContentVC (Uncoupled code.)
+* Call `CFRelease` in `LLAppHelper`.
+* Resolve circular references caused by the `NSURLSessionDelegate` in `LLURLProtocol`.
+* Call `Free` in `LLBaseModel`.
+* Fix analyze warning in `LLBaseViewController` / `LLFilterOtherView`.
+* Uncoupled code in `LLTool` / `LLNetworkContentVC`.
 
-- Just For Demo
+#### Additional Changes
 
-    - NetTool (Use URLSession in a singleton.)
-    - ViewController (Fix a circular reference.)
-    
+* Add `NetTool`(Use URLSession in a singleton.) and update `ViewController` (Fix a circular reference.)
+
 ## [1.0.2](https://github.com/HDB-Li/LLDebugTool/releases/tag/1.0.2) (05/21/2018)
 
 * Fix the side gesture recognizer bug when pop.

--- a/LLDebugTool.podspec
+++ b/LLDebugTool.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name                = "LLDebugTool"
-  s.version             = "1.0.2"
+  s.version             = "1.0.3"
   s.summary             = "LLDebugTool is a debugging tool for developers and testers that can help you analyze and manipulate data in non-xcode situations."
   s.homepage            = "https://github.com/HDB-Li/LLDebugTool"
   s.license             = "MIT"

--- a/LLDebugTool/DebugTool/LLDebugTool.h
+++ b/LLDebugTool/DebugTool/LLDebugTool.h
@@ -65,6 +65,9 @@
  */
 - (void)stopWorking;
 
+/**
+ Whether working or not.
+ */
 @property (nonatomic , assign , readonly) BOOL isWorking;
 
 /**

--- a/LLDebugTool/DebugTool/LLDebugTool.h
+++ b/LLDebugTool/DebugTool/LLDebugTool.h
@@ -71,6 +71,11 @@
 @property (nonatomic , assign , readonly) BOOL isWorking;
 
 /**
+ LLDebugTool's version.
+ */
+@property (nonatomic , copy , readonly) NSString *version;
+
+/**
  Automatic open debug view controller with index.
  */
 - (void)showDebugViewControllerWithIndex:(NSInteger)index;

--- a/LLDebugTool/DebugTool/LLDebugTool.m
+++ b/LLDebugTool/DebugTool/LLDebugTool.m
@@ -86,6 +86,10 @@ static LLDebugTool *_instance = nil;
     }
 }
 
+- (NSString *)version {
+    return @"1.0.3";
+}
+
 - (void)showDebugViewControllerWithIndex:(NSInteger)index {
     [self.window.windowViewController showDebugViewControllerWithIndex:index];
 }

--- a/LLDebugTool/Helper/AppHelper/LLAppHelper.m
+++ b/LLDebugTool/Helper/AppHelper/LLAppHelper.m
@@ -82,7 +82,7 @@ NSString * const LLAppHelperFPSKey = @"LLAppHelperFPSKey";
     loadDate = [[NSDate date] timeIntervalSince1970];
     
     @autoreleasepool {
-        __block id<NSObject> obs;
+        __block __weak id<NSObject> obs;
         obs = [[NSNotificationCenter defaultCenter] addObserverForName:UIApplicationDidFinishLaunchingNotification
                                                                 object:nil queue:nil
                                                             usingBlock:^(NSNotification *note) {
@@ -312,14 +312,18 @@ NSString * const LLAppHelperFPSKey = @"LLAppHelperFPSKey";
 - (NSString *)currentWifiSSID
 {
     NSString *ssid = nil;
-    NSArray *ifs = (__bridge   id)CNCopySupportedInterfaces();
+    CFArrayRef ifRef = CNCopySupportedInterfaces();
+    NSArray *ifs = (__bridge   id)ifRef;
     for (NSString *ifname in ifs) {
-        NSDictionary *info = (__bridge id)CNCopyCurrentNetworkInfo((__bridge CFStringRef)ifname);
+        CFDictionaryRef dictionaryRef = CNCopyCurrentNetworkInfo((__bridge CFStringRef)ifname);
+        NSDictionary *info = (__bridge id)dictionaryRef;
         if (info[@"SSIDD"])
         {
             ssid = info[@"SSID"];
         }
+        CFAutorelease(dictionaryRef);
     }
+    CFAutorelease(ifRef);
     return ssid;
 }
 

--- a/LLDebugTool/Helper/NetworkHelper/NSURLSessionConfiguration+LL_Swizzling.m
+++ b/LLDebugTool/Helper/NetworkHelper/NSURLSessionConfiguration+LL_Swizzling.m
@@ -33,12 +33,29 @@
     Method method1 = class_getClassMethod([NSURLSessionConfiguration class], @selector(defaultSessionConfiguration));
     Method method2 = class_getClassMethod([NSURLSessionConfiguration class], @selector(LL_defaultSessionConfiguration));
     method_exchangeImplementations(method1, method2);
+    
+    Method method3 = class_getClassMethod([NSURLSessionConfiguration class], @selector(ephemeralSessionConfiguration));
+    Method method4 = class_getClassMethod([NSURLSessionConfiguration class], @selector(LL_ephemeralSessionConfiguration));
+    method_exchangeImplementations(method3, method4);
 }
 
 + (NSURLSessionConfiguration *)LL_defaultSessionConfiguration {
     NSURLSessionConfiguration *config = [NSURLSessionConfiguration LL_defaultSessionConfiguration];
     if ([LLDebugTool sharedTool].isWorking) {
         NSMutableArray *protocols = [[NSMutableArray alloc] initWithArray:config.protocolClasses];
+        if (![protocols containsObject:[LLURLProtocol class]]) {
+            [protocols insertObject:[LLURLProtocol class] atIndex:0];
+        }
+        config.protocolClasses = protocols;
+    }
+    return config;
+}
+
++ (NSURLSessionConfiguration *)LL_ephemeralSessionConfiguration {
+    NSURLSessionConfiguration *config = [NSURLSessionConfiguration LL_ephemeralSessionConfiguration];
+    if ([LLDebugTool sharedTool].isWorking) {
+        NSMutableArray *protocols = [[NSMutableArray alloc] init];
+        [protocols addObjectsFromArray:config.protocolClasses];
         if (![protocols containsObject:[LLURLProtocol class]]) {
             [protocols insertObject:[LLURLProtocol class] atIndex:0];
         }

--- a/LLDebugTool/Helper/SandboxHelper/LLSandboxModel.m
+++ b/LLDebugTool/Helper/SandboxHelper/LLSandboxModel.m
@@ -60,9 +60,9 @@
 
 - (instancetype)initWithAttributes:(NSDictionary *)attributes filePath:(NSString *)filePath{
     if (self = [super init]) {
-        _filePath = filePath;
-        _name = [filePath lastPathComponent];
-        _fileType = attributes[NSFileType];
+        _filePath = [filePath copy];
+        _name = [[filePath lastPathComponent] copy];
+        _fileType = [attributes[NSFileType] copy];
         _isDirectory = [_fileType isEqualToString:NSFileTypeDirectory];
         _fileSize = [attributes[NSFileSize] unsignedLongLongValue];
         _totalFileSize = _fileSize;
@@ -86,9 +86,9 @@
     if (!_iconName) {
         if (_isDirectory) {
             if (_subModels.count) {
-                _iconName = kFolderName;
+                _iconName = [kFolderName copy];
             } else {
-                _iconName = kEmptyFolderName;
+                _iconName = [kEmptyFolderName copy];
             }
         } else {
             NSString *extension = self.filePath.pathExtension.lowercaseString;
@@ -112,7 +112,7 @@
                     imageName = kUnknownName;
                 }
             }
-            _iconName = imageName;
+            _iconName = [imageName copy];
         }
     }
     return _iconName;

--- a/LLDebugTool/UserInterface/Base/LLBaseModel.m
+++ b/LLDebugTool/UserInterface/Base/LLBaseModel.m
@@ -71,6 +71,7 @@
             [array addObject:name];
         }
     }
+    free(properties);
     return array;
 }
 

--- a/LLDebugTool/UserInterface/Base/LLBaseViewController.m
+++ b/LLDebugTool/UserInterface/Base/LLBaseViewController.m
@@ -27,6 +27,8 @@
 #import "LLImageNameConfig.h"
 #import "LLWindow.h"
 
+static NSString *const kEmptyCellID = @"emptyCellID";
+
 @interface LLBaseViewController ()
 
 @property (nonatomic , assign) UITableViewStyle style;
@@ -145,7 +147,6 @@
         [btn setImage:[[UIImage imageNamed:kCloseImageName] imageWithRenderingMode:mode] forState:UIControlStateNormal];
         [btn addTarget:self action:@selector(leftItemClick) forControlEvents:UIControlEventTouchUpInside];
     }
-
     self.navigationItem.hidesBackButton = NO;
     self.navigationItem.backBarButtonItem = [[UIBarButtonItem alloc] initWithTitle:@"" style:UIBarButtonItemStylePlain target:self action:@selector(backAction)];
 }
@@ -170,7 +171,11 @@
 }
 
 - (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath {
-    return nil;
+    UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:kEmptyCellID];
+    if (!cell) {
+        cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:kEmptyCellID];
+    }
+    return cell;
 }
 
 @end

--- a/LLDebugTool/UserInterface/Others/FilterView/LLFilterOtherView.m
+++ b/LLDebugTool/UserInterface/Others/FilterView/LLFilterOtherView.m
@@ -237,7 +237,7 @@ static NSString *const kLabelCellID = @"LabelCellID";
         }
         return view;
     }
-    return nil;
+    return [[UICollectionReusableView alloc] init];
 }
 
 - (CGSize)collectionView:(UICollectionView *)collectionView layout:(UICollectionViewLayout *)collectionViewLayout referenceSizeForHeaderInSection:(NSInteger)section {

--- a/LLDebugTool/UserInterface/Sections/Network/LLNetworkContentVC.m
+++ b/LLDebugTool/UserInterface/Sections/Network/LLNetworkContentVC.m
@@ -25,6 +25,7 @@
 #import "LLSubTitleTableViewCell.h"
 #import "LLNetworkImageCell.h"
 #import "LLConfig.h"
+#import "LLTool.h"
 
 static NSString *const kNetworkContentCellID = @"NetworkContentCellID";
 static NSString *const kNetworkImageCellID = @"NetworkImageCellID";
@@ -144,7 +145,7 @@ static NSString *const kNetworkImageCellID = @"NetworkImageCellID";
             if (self.model.isImage) {
                 [self.contentArray addObject:self.model.responseData];
             } else {
-                [self.contentArray addObject:[self prettyJSONStringFromData:self.model.responseData] ?: self.model.responseData];
+                [self.contentArray addObject:[LLTool prettyJSONStringFromData:self.model.responseData] ?: self.model.responseData];
             }
         }
         
@@ -157,25 +158,6 @@ static NSString *const kNetworkImageCellID = @"NetworkImageCellID";
         _canCopyArray = @[@"Request Url",@"Request Body",@"Response Body"];
     }
     return _canCopyArray;
-}
-
-- (NSString *)prettyJSONStringFromData:(NSData *)data
-{
-    if ([data length] == 0) {
-        return nil;
-    }
-    NSString *prettyString = nil;
-    
-    id jsonObject = [NSJSONSerialization JSONObjectWithData:data options:0 error:NULL];
-    if ([NSJSONSerialization isValidJSONObject:jsonObject]) {
-        prettyString = [[NSString alloc] initWithData:[NSJSONSerialization dataWithJSONObject:jsonObject options:NSJSONWritingPrettyPrinted error:NULL] encoding:NSUTF8StringEncoding];
-        // NSJSONSerialization escapes forward slashes. We want pretty json, so run through and unescape the slashes.
-        prettyString = [prettyString stringByReplacingOccurrencesOfString:@"\\/" withString:@"/"];
-    } else {
-        prettyString = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
-    }
-    
-    return prettyString;
 }
 
 - (NSString *)convertDataToHexStr:(NSData *)data

--- a/LLDebugTool/UserInterface/Tool/LLTool.h
+++ b/LLDebugTool/UserInterface/Tool/LLTool.h
@@ -57,10 +57,15 @@
  The only dateformatter for "yyyy-MM-dd HH:mm:ss".
  */
 - (NSDate *)staticDateFromString:(NSString *)string;
+- (NSString *)staticStringFromDate:(NSDate *)date;
 
 /**
  Create lines of unity.
  */
 + (UIView *)lineView:(CGRect)frame superView:(UIView *)superView;
 
+/**
+ Convert data to JSONString.
+ */
++ (NSString *)prettyJSONStringFromData:(NSData *)data;
 @end

--- a/LLDebugTool/UserInterface/Tool/LLTool.m
+++ b/LLDebugTool/UserInterface/Tool/LLTool.m
@@ -72,6 +72,10 @@ static LLTool *_instance = nil;
     return [self.staticDateFormatter dateFromString:string];
 }
 
+- (NSString *)staticStringFromDate:(NSDate *)date {
+    return [self.staticDateFormatter stringFromDate:date];
+}
+
 + (UIView *)lineView:(CGRect)frame superView:(UIView *)superView {
     UIView *view = [[UIView alloc] initWithFrame:frame];
     view.backgroundColor = [UIColor lightGrayColor];
@@ -82,6 +86,25 @@ static LLTool *_instance = nil;
         [superView addSubview:view];
     }
     return view;
+}
+
++ (NSString *)prettyJSONStringFromData:(NSData *)data
+{
+    if ([data length] == 0) {
+        return nil;
+    }
+    NSString *prettyString = nil;
+    
+    id jsonObject = [NSJSONSerialization JSONObjectWithData:data options:0 error:NULL];
+    if ([NSJSONSerialization isValidJSONObject:jsonObject]) {
+        prettyString = [[NSString alloc] initWithData:[NSJSONSerialization dataWithJSONObject:jsonObject options:NSJSONWritingPrettyPrinted error:NULL] encoding:NSUTF8StringEncoding];
+        // NSJSONSerialization escapes forward slashes. We want pretty json, so run through and unescape the slashes.
+        prettyString = [prettyString stringByReplacingOccurrencesOfString:@"\\/" withString:@"/"];
+    } else {
+        prettyString = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
+    }
+    
+    return prettyString;
 }
 
 #pragma mark - Lazy load

--- a/LLDebugToolDemo/NetTool.h
+++ b/LLDebugToolDemo/NetTool.h
@@ -1,0 +1,22 @@
+//
+//  NetTool.h
+//  LLDebugToolDemo
+//
+//  Created by Li on 2018/5/30.
+//  Copyright © 2018年 li. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import <AFNetworking.h>
+
+@interface NetTool : NSObject
+
++ (instancetype)sharedTool;
+
+@property (nonatomic , strong) NSURLSession *session;
+
+@property (nonatomic , strong) AFURLSessionManager *afURLSessionManager;
+
+@property (nonatomic , strong) AFHTTPSessionManager *afHTTPSessionManager;
+
+@end

--- a/LLDebugToolDemo/NetTool.m
+++ b/LLDebugToolDemo/NetTool.m
@@ -1,0 +1,44 @@
+//
+//  NetTool.m
+//  LLDebugToolDemo
+//
+//  Created by Li on 2018/5/30.
+//  Copyright © 2018年 li. All rights reserved.
+//
+
+#import "NetTool.h"
+
+static NetTool *_instance = nil;
+
+@implementation NetTool
+
++ (instancetype)sharedTool {
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        _instance = [[NetTool alloc] init];
+    });
+    return _instance;
+}
+
+- (NSURLSession *)session {
+    if (!_session) {
+        _session = [NSURLSession sessionWithConfiguration:[NSURLSessionConfiguration defaultSessionConfiguration]];
+    }
+    return _session;
+}
+
+-(AFURLSessionManager *)afURLSessionManager {
+    if (!_afURLSessionManager) {
+        _afURLSessionManager = [[AFURLSessionManager alloc] initWithSessionConfiguration:[NSURLSessionConfiguration defaultSessionConfiguration]];
+    }
+    return _afURLSessionManager;
+}
+
+- (AFHTTPSessionManager *)afHTTPSessionManager {
+    if (!_afHTTPSessionManager) {
+        _afHTTPSessionManager = [AFHTTPSessionManager manager];
+    }
+    return _afHTTPSessionManager;
+}
+
+@end

--- a/LLDebugToolDemo/ViewController.m
+++ b/LLDebugToolDemo/ViewController.m
@@ -10,7 +10,7 @@
 #import "LLDebug.h"
 
 // Used to example.
-#import <AFNetworking.h>
+#import "NetTool.h"
 
 static NSString *const kCellID = @"cellID";
 
@@ -19,14 +19,13 @@ static NSString *const kCellID = @"cellID";
 @property (weak, nonatomic) IBOutlet UIImageView *imgView;
 @property (weak, nonatomic) IBOutlet UITableView *tableView;
 
-@property (strong , nonatomic) AFHTTPSessionManager *manager;
-
 @end
 
 @implementation ViewController
 
 - (void)viewDidLoad {
     [super viewDidLoad];
+    
     // LLDebugTool need time to start.
     sleep(0.5);
     __block __weak typeof(self) weakSelf = self;
@@ -51,10 +50,13 @@ static NSString *const kCellID = @"cellID";
             }
         });
     }];
-
+    
+    
     // Json Response
-    [self.manager GET:@"http://baike.baidu.com/api/openapi/BaikeLemmaCardApi?&format=json&appid=379020&bk_key=%E7%81%AB%E5%BD%B1%E5%BF%8D%E8%80%85&bk_length=600" parameters:nil progress:nil success:^(NSURLSessionDataTask * _Nonnull task, id  _Nullable responseObject) {
+    [[NetTool sharedTool].afHTTPSessionManager GET:@"http://baike.baidu.com/api/openapi/BaikeLemmaCardApi?&format=json&appid=379020&bk_key=%E7%81%AB%E5%BD%B1%E5%BF%8D%E8%80%85&bk_length=600" parameters:nil progress:nil success:^(NSURLSessionDataTask * _Nonnull task, id  _Nullable responseObject) {
+        
     } failure:^(NSURLSessionDataTask * _Nullable task, NSError * _Nonnull error) {
+        
     }];
     
     // Log.
@@ -68,7 +70,7 @@ static NSString *const kCellID = @"cellID";
     NSString *url = @"http://baike.baidu.com/api/openapi/BaikeLemmaCardApi?&format=json&appid=379020&bk_key=%E7%81%AB%E5%BD%B1%E5%BF%8D%E8%80%85&bk_length=600";
     
     // Use AFHttpSessionManager
-    [self.manager GET:url parameters:nil progress:nil success:^(NSURLSessionDataTask * _Nonnull task, id  _Nullable responseObject) {
+    [[NetTool sharedTool].afHTTPSessionManager GET:url parameters:nil progress:nil success:^(NSURLSessionDataTask * _Nonnull task, id  _Nullable responseObject) {
         [[LLDebugTool sharedTool] showDebugViewControllerWithIndex:0];
     } failure:^(NSURLSessionDataTask * _Nullable task, NSError * _Nonnull error) {
         [[LLDebugTool sharedTool] showDebugViewControllerWithIndex:0];
@@ -76,9 +78,8 @@ static NSString *const kCellID = @"cellID";
     
     // Use AFURLSessionManager
     /*
-    AFURLSessionManager *manager = [[AFURLSessionManager alloc] init];
     NSURLRequest *request = [[NSURLRequest alloc] initWithURL:[NSURL URLWithString:url]];
-    [manager dataTaskWithRequest:request uploadProgress:nil downloadProgress:nil completionHandler:^(NSURLResponse * _Nonnull response, id  _Nullable responseObject, NSError * _Nullable error) {
+    [[NetTool sharedTool].afURLSessionManager dataTaskWithRequest:request uploadProgress:nil downloadProgress:nil completionHandler:^(NSURLResponse * _Nonnull response, id  _Nullable responseObject, NSError * _Nullable error) {
         [[LLDebugTool sharedTool] showDebugViewControllerWithIndex:0];
     }];
      */
@@ -95,10 +96,9 @@ static NSString *const kCellID = @"cellID";
 
 - (void)testHTMLNetworkRequest {
     //NSURLSession
-    NSURLSession *session = [NSURLSession sharedSession];
     NSMutableURLRequest *urlRequest = [[NSMutableURLRequest alloc] initWithURL:[NSURL URLWithString:@"https://www.baidu.com"]];
     [urlRequest setHTTPMethod:@"GET"];
-    NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:urlRequest completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
+    NSURLSessionDataTask *dataTask = [[NetTool sharedTool].session dataTaskWithRequest:urlRequest completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
         [[LLDebugTool sharedTool] showDebugViewControllerWithIndex:0];
     }];
     [dataTask resume];
@@ -284,14 +284,6 @@ static NSString *const kCellID = @"cellID";
         return @"Config";
     }
     return nil;
-}
-
-#pragma mark - Lazy Load
-- (AFHTTPSessionManager *)manager {
-    if (!_manager) {
-        _manager = [AFHTTPSessionManager manager];
-    }
-    return _manager;
 }
 
 @end

--- a/LLDebugToolDemo/ViewController.m
+++ b/LLDebugToolDemo/ViewController.m
@@ -8,8 +8,9 @@
 
 #import "ViewController.h"
 #import "LLDebug.h"
+
+// Used to example.
 #import <AFNetworking.h>
-#import "LLURLProtocol.h"
 
 static NSString *const kCellID = @"cellID";
 
@@ -17,6 +18,8 @@ static NSString *const kCellID = @"cellID";
 
 @property (weak, nonatomic) IBOutlet UIImageView *imgView;
 @property (weak, nonatomic) IBOutlet UITableView *tableView;
+
+@property (strong , nonatomic) AFHTTPSessionManager *manager;
 
 @end
 
@@ -26,6 +29,7 @@ static NSString *const kCellID = @"cellID";
     [super viewDidLoad];
     // LLDebugTool need time to start.
     sleep(0.5);
+    __block __weak typeof(self) weakSelf = self;
     
     if ([[NSUserDefaults standardUserDefaults] boolForKey:@"openCrash"]) {
         [[NSUserDefaults standardUserDefaults] setBool:NO forKey:@"openCrash"];
@@ -43,17 +47,19 @@ static NSString *const kCellID = @"cellID";
         dispatch_async(dispatch_get_main_queue(), ^{
             if (!connectionError) {
                 UIImage *image = [[UIImage alloc] initWithData:data];
-                self.imgView.image = image;
+                weakSelf.imgView.image = image;
             }
         });
     }];
 
     // Json Response
-    [[AFHTTPSessionManager manager] GET:@"http://baike.baidu.com/api/openapi/BaikeLemmaCardApi?&format=json&appid=379020&bk_key=%E7%81%AB%E5%BD%B1%E5%BF%8D%E8%80%85&bk_length=600" parameters:nil progress:nil success:^(NSURLSessionDataTask * _Nonnull task, id  _Nullable responseObject) {
+    [self.manager GET:@"http://baike.baidu.com/api/openapi/BaikeLemmaCardApi?&format=json&appid=379020&bk_key=%E7%81%AB%E5%BD%B1%E5%BF%8D%E8%80%85&bk_length=600" parameters:nil progress:nil success:^(NSURLSessionDataTask * _Nonnull task, id  _Nullable responseObject) {
     } failure:^(NSURLSessionDataTask * _Nullable task, NSError * _Nonnull error) {
     }];
     
-    // Log
+    // Log.
+    // NSLocalizedString is used for multiple languages.
+    // You can just use as LLog(@"What you want to pring").
     LLog(NSLocalizedString(@"initial.log", nil));
 }
 
@@ -62,7 +68,7 @@ static NSString *const kCellID = @"cellID";
     NSString *url = @"http://baike.baidu.com/api/openapi/BaikeLemmaCardApi?&format=json&appid=379020&bk_key=%E7%81%AB%E5%BD%B1%E5%BF%8D%E8%80%85&bk_length=600";
     
     // Use AFHttpSessionManager
-    [[AFHTTPSessionManager manager] GET:url parameters:nil progress:nil success:^(NSURLSessionDataTask * _Nonnull task, id  _Nullable responseObject) {
+    [self.manager GET:url parameters:nil progress:nil success:^(NSURLSessionDataTask * _Nonnull task, id  _Nullable responseObject) {
         [[LLDebugTool sharedTool] showDebugViewControllerWithIndex:0];
     } failure:^(NSURLSessionDataTask * _Nullable task, NSError * _Nonnull error) {
         [[LLDebugTool sharedTool] showDebugViewControllerWithIndex:0];
@@ -278,6 +284,14 @@ static NSString *const kCellID = @"cellID";
         return @"Config";
     }
     return nil;
+}
+
+#pragma mark - Lazy Load
+- (AFHTTPSessionManager *)manager {
+    if (!_manager) {
+        _manager = [AFHTTPSessionManager manager];
+    }
+    return _manager;
 }
 
 @end

--- a/README-cn.md
+++ b/README-cn.md
@@ -3,11 +3,14 @@
 </p>
 
 [![Version](https://img.shields.io/badge/IOS-%3E%3D8.0-f07e48.svg)](https://img.shields.io/badge/IOS-%3E%3D8.0-f07e48.svg)
-[![CocoaPods Compatible](https://img.shields.io/badge/pod-v1.0.2-blue.svg)](https://img.shields.io/badge/pod-v1.0.2-blue.svg)
+[![CocoaPods Compatible](https://img.shields.io/badge/pod-v1.0.3-blue.svg)](https://img.shields.io/badge/pod-v1.0.3-blue.svg)
 [![Platform](https://img.shields.io/badge/platform-ios-lightgrey.svg)](https://img.shields.io/badge/platform-ios-lightgrey.svg)
 [![License](https://img.shields.io/badge/license-MIT-91bc2b.svg)](https://img.shields.io/badge/license-MIT-91bc2b.svg)
+[![Language](https://img.shields.io/badge/Language-Objective--C-yellow.svg)](https://img.shields.io/badge/Language-Objective--C-yellow.svg)
 
-[English Introduction](https://github.com/HDB-Li/LLDebugTool)
+## 简介
+
+[Click here for an English introduction](https://github.com/HDB-Li/LLDebugTool)
 
 LLDebugTool是一款针对开发者和测试者的调试工具，它可以帮助你在非Xcode的情况下，进行数据分析和操作。
 
@@ -21,6 +24,10 @@ LLDebugTool是一款针对开发者和测试者的调试工具，它可以帮助
 <img src="https://raw.githubusercontent.com/HDB-Li/HDBImageRepository/master/LLDebugTool/ScreenShot-5.png" width="15%"> </img>
 <img src="https://raw.githubusercontent.com/HDB-Li/HDBImageRepository/master/LLDebugTool/ScreenShot-6.png" width="15%"> </img>
 </div>
+
+## 最近更新 (1.0.3)
+
+- 修复一些内存泄漏问题。
 
 ## 我能用LLDebugTool做什么?
 

--- a/README.md
+++ b/README.md
@@ -3,11 +3,14 @@
 </p>
 
 [![Version](https://img.shields.io/badge/IOS-%3E%3D8.0-f07e48.svg)](https://img.shields.io/badge/IOS-%3E%3D8.0-f07e48.svg)
-[![CocoaPods Compatible](https://img.shields.io/badge/pod-v1.0.2-blue.svg)](https://img.shields.io/badge/pod-v1.0.2-blue.svg)
+[![CocoaPods Compatible](https://img.shields.io/badge/pod-v1.0.3-blue.svg)](https://img.shields.io/badge/pod-v1.0.3-blue.svg)
 [![Platform](https://img.shields.io/badge/platform-ios-lightgrey.svg)](https://img.shields.io/badge/platform-ios-lightgrey.svg)
 [![License](https://img.shields.io/badge/license-MIT-91bc2b.svg)](https://img.shields.io/badge/license-MIT-91bc2b.svg)
+[![Language](https://img.shields.io/badge/Language-Objective--C-yellow.svg)](https://img.shields.io/badge/Language-Objective--C-yellow.svg)
 
-[中文简介](https://github.com/HDB-Li/LLDebugTool/blob/master/README-cn.md)
+## Introduction
+
+[点击查看中文简介](https://github.com/HDB-Li/LLDebugTool/blob/master/README-cn.md)
 
 LLDebugTool is a debugging tool for developers and testers that can help you analyze and manipulate data in non-xcode situations.
 
@@ -22,6 +25,10 @@ Choose LLDebugTool for your next project, or migrate over your existing projects
 <img src="https://raw.githubusercontent.com/HDB-Li/HDBImageRepository/master/LLDebugTool/ScreenShot-6.png" width="15%"> </img>
 </div>
 
+## Recent updates (1.0.3) 
+
+- Fix some leaks.
+        
 ## What can you do with LLDebugTool?
 
 - Always check the network request or view log information for certain events without having to run under XCode. This is useful in solving the testers' problems..


### PR DESCRIPTION
Fix some leaks.

#### Update

* Call `CFRelease` in `LLAppHelper`.
* Resolve circular references caused by the `NSURLSessionDelegate` in `LLURLProtocol`.
* Call `Free` in `LLBaseModel`.
* Fix analyze warning in `LLBaseViewController` / `LLFilterOtherView`.
* Uncoupled code in `LLTool` / `LLNetworkContentVC`.

#### Additional Changes

* Add `NetTool`(Use URLSession in a singleton.) and update `ViewController` (Fix a circular reference.)