### PR TITLE
1.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,26 @@
+## [1.1.4](https://github.com/HDB-Li/LLDebugTool/releases/tag/1.1.4) (08/27/2018)
+
+### Increase network traffic monitoring
+
+Now you can check your network request traffic, although it is not very accurate. Other some known problems have been fixed. More changes can be viewed in [Project 1.1.4](https://github.com/HDB-Li/LLDebugTool/projects/3).
+
+#### Add
+
+* Add data traffic function, details can see `LLNetworkModel.m`.
+
+#### Update
+
+* Update the constraints in all XIB files, remove constraint warnings from the console.
+* Use `UITextView` replace `UILabel` in `LLSubTitleTableViewCell`, used to solve the problem that `UILabel` does not show when there is too much data, such as 1000 lines.
+* Use `MIMETYPE` to judge the type of a network response.
+* Update `LLAppHelper.h`, expose more interfaces.
+* Update `LLStorageManager`, rewritten SQL statements.
+
+#### Extra
+
+* Now we can display GIF images.
+* Fix some bugs.
+
 ## [1.1.3](https://github.com/HDB-Li/LLDebugTool/releases/tag/1.1.3) (08/16/2018)
 
 ### Refactory database

--- a/LLDebugTool.podspec
+++ b/LLDebugTool.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name                = "LLDebugTool"
-  s.version             = "1.1.3"
+  s.version             = "1.1.4"
   s.summary             = "LLDebugTool is a debugging tool for developers and testers that can help you analyze and manipulate data in non-xcode situations."
   s.homepage            = "https://github.com/HDB-Li/LLDebugTool"
   s.license             = "MIT"

--- a/LLDebugTool/DebugTool/LLDebugTool.m
+++ b/LLDebugTool/DebugTool/LLDebugTool.m
@@ -115,8 +115,8 @@ static LLDebugTool *_instance = nil;
  */
 - (void)initial {
     // Set Default
-    _isBetaVersion = NO;
-    _versionNumber = @"1.1.3";
+    _isBetaVersion = YES;
+    _versionNumber = @"1.1.4";
     _version = _isBetaVersion ? [_versionNumber stringByAppendingString:@"(BETA)"] : _versionNumber;
     
     // Check version.

--- a/LLDebugTool/Helper/AppHelper/LLAppHelper.h
+++ b/LLDebugTool/Helper/AppHelper/LLAppHelper.h
@@ -25,18 +25,24 @@
 #import <UIKit/UIKit.h>
 
 /**
- Notifications when CPU / Memory / FPS updates.
+ Notifications will post each second on main thread.
  Cpu is between 0.0% to 100.0%.
  Memory's unit is byte.
- Fps is float between 0.0 to 60.0
+ Fps is float between 0.0 to 60.0.
+ Request data traffic is upload data.
+ Response data traffic is download data.
+ Total data traffic is total data.
  */
 UIKIT_EXTERN NSNotificationName const LLAppHelperDidUpdateAppInfosNotificationName;
+
 UIKIT_EXTERN NSString * const LLAppHelperCPUKey;
 UIKIT_EXTERN NSString * const LLAppHelperMemoryUsedKey;
 UIKIT_EXTERN NSString * const LLAppHelperMemoryFreeKey;
 UIKIT_EXTERN NSString * const LLAppHelperMemoryTotalKey;
 UIKIT_EXTERN NSString * const LLAppHelperFPSKey;
-UIKIT_EXTERN NSString * const LLAppHelperDataTrafficKey;
+UIKIT_EXTERN NSString * const LLAppHelperRequestDataTrafficKey;
+UIKIT_EXTERN NSString * const LLAppHelperResponseDataTrafficKey;
+UIKIT_EXTERN NSString * const LLAppHelperTotalDataTrafficKey;
 
 /**
  Monitoring app's properties.
@@ -48,7 +54,7 @@ UIKIT_EXTERN NSString * const LLAppHelperDataTrafficKey;
  
  @return Singleton
  */
-+ (instancetype)sharedHelper;
++ (instancetype _Nonnull)sharedHelper;
 
 /**
  Start monitoring CPU/FPS/Memory
@@ -61,19 +67,111 @@ UIKIT_EXTERN NSString * const LLAppHelperDataTrafficKey;
 - (void)stopMonitoring;
 
 /**
- Get current app infos.Include "CPU Usage","Memory Usage","FPS","Data Traffic","App Name","Bundle Identifier","App Version","App Start Time","Device Model","Phone Name","System Version","Screen Resolution","Language Code","Battery Level","CPU Type","Disk","Network State" and "SSID".
+ Get current app infos. Include "CPU Usage","Memory Usage","FPS","Data Traffic","App Name","Bundle Identifier","App Version","App Start Time","Device Model","Device Name","System Version","Screen Resolution","Language Code","Battery Level","CPU Type","Disk","Network State" and "SSID".
  */
-- (NSMutableArray <NSArray <NSDictionary *>*>*)appInfos;
+- (NSMutableArray <NSArray <NSDictionary <NSString *,NSString *>*>*>*_Nonnull)appInfos;
 
 /**
- Update data traffic when finish a network request.
+ Current cpu usage.
  */
-- (void)updateRequestDataTraffic:(unsigned long long)requestDataTraffic responseDataTraffic:(unsigned long long)responseDataTraffic;
+- (NSString *_Nonnull)cpuUsage;
+
+/**
+ Current memory usage.
+ */
+- (NSString *_Nonnull)memoryUsage;
+
+/**
+ Current FPS.
+ */
+- (NSString *_Nonnull)fps;
+
+/**
+ Current data traffic.
+ Format is "{totalDataTraffic}  (Upload : {requestDataTraffic} / Download : {responseDataTraffic})"
+ */
+- (NSString *_Nonnull)dataTraffic;
+
+/**
+ Application name.
+ */
+- (NSString *_Nonnull)appName;
+
+/**
+ Application bundle identifier.
+ */
+- (NSString *_Nonnull)bundleIdentifier;
+
+/**
+ Application version.
+ */
+- (NSString *_Nonnull)appVersion;
+
+/**
+ Application start time consuming.
+ */
+- (NSString *_Nonnull)appStartTimeConsuming;
+
+/**
+ Device model.
+ */
+- (NSString *_Nonnull)deviceModel;
+
+/**
+ Device name.
+ */
+- (NSString *_Nonnull)deviceName;
+
+/**
+ Device system version.
+ */
+- (NSString *_Nonnull)systemVersion;
+
+/**
+ Device screen resolution.
+ */
+- (NSString *_Nonnull)screenResolution;
+
+/**
+ Current languageCode.
+ */
+- (NSString *_Nonnull)languageCode;
+
+/**
+ Current battery level.
+ */
+- (NSString *_Nonnull)batteryLevel;
+
+/**
+ Current cpu type.
+ */
+- (NSString *_Nonnull)cpuType;
+
+/**
+ Current disk infos.
+ */
+- (NSString *_Nonnull)disk;
+
+/**
+ Current network state.
+ */
+- (NSString *_Nonnull)networkState;
+
+/**
+ Current ssid.
+ */
+- (NSString *_Nullable)ssid;
 
 #pragma mark - DEPRECATED
 /**
  Get this time launchDate. LaunchDate means the start time of the app, also it's the identity for crash model.
  */
-- (NSString *)launchDate DEPRECATED_MSG_ATTRIBUTE("Use [NSObject launchDate] replace.");
+- (NSString *_Nonnull)launchDate DEPRECATED_MSG_ATTRIBUTE("Use [NSObject launchDate] replace.");
+
+#pragma mark - PRIMARY (This part of the method is used for internal calls, and users do not actively invoke these interfaces, nor need to care about them.)
+/**
+ Update data traffic when finish a network request.
+ */
+- (void)updateRequestDataTraffic:(unsigned long long)requestDataTraffic responseDataTraffic:(unsigned long long)responseDataTraffic;
 
 @end

--- a/LLDebugTool/Helper/AppHelper/LLAppHelper.h
+++ b/LLDebugTool/Helper/AppHelper/LLAppHelper.h
@@ -88,7 +88,7 @@ UIKIT_EXTERN NSString * const LLAppHelperTotalDataTrafficKey;
 
 /**
  Current data traffic.
- Format is "{totalDataTraffic}  (Upload : {requestDataTraffic} / Download : {responseDataTraffic})"
+ Format is "{total} ({upload}↑ / {download}↓)"
  */
 - (NSString *_Nonnull)dataTraffic;
 

--- a/LLDebugTool/Helper/AppHelper/LLAppHelper.h
+++ b/LLDebugTool/Helper/AppHelper/LLAppHelper.h
@@ -60,9 +60,14 @@ UIKIT_EXTERN NSString * const LLAppHelperFPSKey;
 - (void)stopMonitoring;
 
 /**
- Get current app infos.Include "CPU Usage","Memory Usage","FPS","App Name","Bundle Identifier","App Version","App Start Time","Device Model","Phone Name","System Version","Screen Resolution","Language Code","Battery Level","CPU Type","Disk","Network State" and "SSID".
+ Get current app infos.Include "CPU Usage","Memory Usage","FPS","Data Traffic","App Name","Bundle Identifier","App Version","App Start Time","Device Model","Phone Name","System Version","Screen Resolution","Language Code","Battery Level","CPU Type","Disk","Network State" and "SSID".
  */
 - (NSMutableArray <NSArray <NSDictionary *>*>*)appInfos;
+
+/**
+ Update data traffic.
+ */
+- (void)updateRequestDataTraffic:(unsigned long long)requestDataTraffic responseDataTraffic:(unsigned long long)responseDataTraffic;
 
 #pragma mark - DEPRECATED
 /**

--- a/LLDebugTool/Helper/AppHelper/LLAppHelper.h
+++ b/LLDebugTool/Helper/AppHelper/LLAppHelper.h
@@ -36,6 +36,7 @@ UIKIT_EXTERN NSString * const LLAppHelperMemoryUsedKey;
 UIKIT_EXTERN NSString * const LLAppHelperMemoryFreeKey;
 UIKIT_EXTERN NSString * const LLAppHelperMemoryTotalKey;
 UIKIT_EXTERN NSString * const LLAppHelperFPSKey;
+UIKIT_EXTERN NSString * const LLAppHelperDataTrafficKey;
 
 /**
  Monitoring app's properties.
@@ -65,7 +66,7 @@ UIKIT_EXTERN NSString * const LLAppHelperFPSKey;
 - (NSMutableArray <NSArray <NSDictionary *>*>*)appInfos;
 
 /**
- Update data traffic.
+ Update data traffic when finish a network request.
  */
 - (void)updateRequestDataTraffic:(unsigned long long)requestDataTraffic responseDataTraffic:(unsigned long long)responseDataTraffic;
 

--- a/LLDebugTool/Helper/AppHelper/LLAppHelper.h
+++ b/LLDebugTool/Helper/AppHelper/LLAppHelper.h
@@ -33,16 +33,16 @@
  Response data traffic is download data.
  Total data traffic is total data.
  */
-UIKIT_EXTERN NSNotificationName const LLAppHelperDidUpdateAppInfosNotificationName;
+UIKIT_EXTERN NSNotificationName _Nonnull const LLAppHelperDidUpdateAppInfosNotificationName;
 
-UIKIT_EXTERN NSString * const LLAppHelperCPUKey;
-UIKIT_EXTERN NSString * const LLAppHelperMemoryUsedKey;
-UIKIT_EXTERN NSString * const LLAppHelperMemoryFreeKey;
-UIKIT_EXTERN NSString * const LLAppHelperMemoryTotalKey;
-UIKIT_EXTERN NSString * const LLAppHelperFPSKey;
-UIKIT_EXTERN NSString * const LLAppHelperRequestDataTrafficKey;
-UIKIT_EXTERN NSString * const LLAppHelperResponseDataTrafficKey;
-UIKIT_EXTERN NSString * const LLAppHelperTotalDataTrafficKey;
+UIKIT_EXTERN NSString * _Nonnull const LLAppHelperCPUKey;
+UIKIT_EXTERN NSString * _Nonnull const LLAppHelperMemoryUsedKey;
+UIKIT_EXTERN NSString * _Nonnull const LLAppHelperMemoryFreeKey;
+UIKIT_EXTERN NSString * _Nonnull const LLAppHelperMemoryTotalKey;
+UIKIT_EXTERN NSString * _Nonnull const LLAppHelperFPSKey;
+UIKIT_EXTERN NSString * _Nonnull const LLAppHelperRequestDataTrafficKey;
+UIKIT_EXTERN NSString * _Nonnull const LLAppHelperResponseDataTrafficKey;
+UIKIT_EXTERN NSString * _Nonnull const LLAppHelperTotalDataTrafficKey;
 
 /**
  Monitoring app's properties.

--- a/LLDebugTool/Helper/AppHelper/LLAppHelper.m
+++ b/LLDebugTool/Helper/AppHelper/LLAppHelper.m
@@ -30,6 +30,8 @@
 #import "LLMacros.h"
 #import "LLTool.h"
 #import "NSObject+LL_Utils.h"
+#import <ifaddrs.h>
+#import <net/if.h>
 
 static LLAppHelper *_instance = nil;
 
@@ -39,6 +41,7 @@ NSString * const LLAppHelperMemoryUsedKey = @"LLAppHelperMemoryUsedKey";
 NSString * const LLAppHelperMemoryFreeKey = @"LLAppHelperMemoryFreeKey";
 NSString * const LLAppHelperMemoryTotalKey = @"LLAppHelperMemoryTotalKey";
 NSString * const LLAppHelperFPSKey = @"LLAppHelperFPSKey";
+NSString * const LLAppHelperDataTrafficKey = @"LLAppHelperDataTrafficKey";
 
 @interface LLAppHelper ()
 {
@@ -63,6 +66,8 @@ NSString * const LLAppHelperFPSKey = @"LLAppHelperFPSKey";
     NSString *_phoneName;
     NSString *_systemVersion;
     NSString *_screenResolution;
+    NSString *_languageCode;
+    NSString *_cpuType;
 }
 
 @property (nonatomic , strong) NSTimer *memoryTimer;
@@ -117,33 +122,14 @@ NSString * const LLAppHelperFPSKey = @"LLAppHelperFPSKey";
 }
 
 - (NSMutableArray <NSArray <NSDictionary *>*>*)appInfos {
-//    NSArray *dynamic = [[NSArray alloc] initWithObjects:@{@"CPU Usage" : [self CPUUsage]},@{@"Memory Usage" : [self MemoryUsage]},@{@"FPS" : [self FPS]},@{@"Data Traffic" : [self dataTraffic]},nil];
-    NSArray *dynamic = @[@{@"CPU Usage" : [self cpuUsage]},
-                         @{@"Memory Usage" : [self memoryUsage]},
-                         @{@"FPS" : [self fps]},
-                         @{@"Data Traffic" : [self dataTraffic]}];
+    
+    NSArray *dynamic = [self dynamicInfos];
     
     // App Info
-    NSArray *apps = @[@{@"App Name" : [self appName]},
-                      @{@"Bundle Identifier" : [self bundleIdentifier]},
-                      @{@"App Version" : [self appVersion]},
-                      @{@"App Start Time" : [self appStartTime]}];
+    NSArray *apps = [self applicationInfos];
 
     // Device Info
-    NSArray *devices = @[@{@"Device Model" : [self deviceModel]},
-                         @{@"Phone Name" : [self phoneName]},
-                         @{@"System Version" : [self systemVersion]},
-                         @{@"Screen Resolution" : [self screenResolution]},
-                         @{@"Language Code" : [NSLocale preferredLanguages].firstObject ?: @"Unknown"},
-                         @{@"Battery Level" : [UIDevice currentDevice].batteryLevel != -1 ? [NSString stringWithFormat:@"%ld%%",(long)([UIDevice currentDevice].batteryLevel * 100)] : @"Unknown"},
-                         @{@"CPU Type" : [self cpuSubtypeString] ?: @"Unknown"},
-                         @{@"Disk" : [NSString stringWithFormat:@"%@ / %@", [NSByteCountFormatter stringFromByteCount:[self getFreeDisk] countStyle:NSByteCountFormatterCountStyleFile],[NSByteCountFormatter stringFromByteCount:[self getTotalDisk] countStyle:NSByteCountFormatterCountStyleFile]]},
-                         @{@"Network State" : [self networkStateFromStatebar]}];
-    NSMutableArray *mutDevices = [[NSMutableArray alloc] initWithArray:devices];
-    NSString *ssid = [self currentWifiSSID];
-    if (ssid) {
-        [mutDevices insertObject:@{@"SSID" : ssid} atIndex:7];
-    }
+    NSArray *devices = [self deviceInfos];
     
     return [[NSMutableArray alloc] initWithObjects:dynamic ,apps, devices, nil];
 }
@@ -171,6 +157,7 @@ NSString * const LLAppHelperFPSKey = @"LLAppHelperFPSKey";
 }
 
 - (NSString *)dataTraffic {
+    return [self dataCounter];
     NSString *total = [NSByteCountFormatter stringFromByteCount:_totalDataTraffic countStyle:NSByteCountFormatterCountStyleFile];
     NSString *request = [NSByteCountFormatter stringFromByteCount:_requestDataTraffic countStyle:NSByteCountFormatterCountStyleFile];
     NSString *response = [NSByteCountFormatter stringFromByteCount:_responseDataTraffic countStyle:NSByteCountFormatterCountStyleFile];
@@ -236,6 +223,44 @@ NSString * const LLAppHelperFPSKey = @"LLAppHelperFPSKey";
     return _screenResolution;
 }
 
+- (NSString *)languageCode {
+    if (!_languageCode) {
+        _languageCode = [NSLocale preferredLanguages].firstObject ?: @"Unknown";
+    }
+    return _languageCode;
+}
+
+- (NSString *)batteryLevel {
+    return [UIDevice currentDevice].batteryLevel != -1 ? [NSString stringWithFormat:@"%ld%%",(long)([UIDevice currentDevice].batteryLevel * 100)] : @"Unknown";
+}
+
+- (NSString *)cpuType {
+    return [self cpuSubtypeString] ?: @"Unknown";
+}
+
+- (NSString *)disk {
+    NSString *free = [NSByteCountFormatter stringFromByteCount:[self getFreeDisk] countStyle:NSByteCountFormatterCountStyleFile];
+    NSString *total = [NSByteCountFormatter stringFromByteCount:[self getTotalDisk] countStyle:NSByteCountFormatterCountStyleFile];
+    return [NSString stringWithFormat:@"%@ / %@", free,total];
+}
+
+- (NSString *)networkState {
+    return [self networkStateFromStatebar];
+}
+
+- (NSString *)ssid {
+    return [self currentWifiSSID];
+}
+
+- (NSString *)dataCounter {
+    NSArray *datas = [self dataCounters];
+    NSString *wifiSent = [NSByteCountFormatter stringFromByteCount:[datas[0] unsignedLongLongValue] countStyle:NSByteCountFormatterCountStyleFile];
+    NSString *wifiReceived = [NSByteCountFormatter stringFromByteCount:[datas[1] unsignedLongLongValue] countStyle:NSByteCountFormatterCountStyleFile];
+    NSString *WWANSent = [NSByteCountFormatter stringFromByteCount:[datas[2] unsignedLongLongValue] countStyle:NSByteCountFormatterCountStyleFile];
+    NSString *WWANReceived = [NSByteCountFormatter stringFromByteCount:[datas[3] unsignedLongLongValue] countStyle:NSByteCountFormatterCountStyleFile];
+    return [NSString stringWithFormat:@"%@,%@,%@,%@",wifiSent,wifiReceived,WWANSent,WWANReceived];
+}
+
 - (NSString *)launchDate {
     return [NSObject launchDate];
 }
@@ -246,6 +271,39 @@ NSString * const LLAppHelperFPSKey = @"LLAppHelperFPSKey";
  */
 - (void)initial {
     _fps = 60;
+}
+
+- (NSArray *)dynamicInfos {
+    return @[@{@"CPU Usage" : [self cpuUsage]},
+             @{@"Memory Usage" : [self memoryUsage]},
+             @{@"FPS" : [self fps]},
+             @{@"Data Traffic" : [self dataTraffic]}];
+}
+
+- (NSArray *)applicationInfos {
+    return @[@{@"App Name" : [self appName]},
+             @{@"Bundle Identifier" : [self bundleIdentifier]},
+             @{@"App Version" : [self appVersion]},
+             @{@"App Start Time" : [self appStartTime]}];
+}
+
+- (NSArray *)deviceInfos {
+    NSArray *devices = @[@{@"Device Model" : [self deviceModel]},
+                         @{@"Phone Name" : [self phoneName]},
+                         @{@"System Version" : [self systemVersion]},
+                         @{@"Screen Resolution" : [self screenResolution]},
+                         @{@"Language Code" : [self languageCode]},
+                         @{@"Battery Level" : [self batteryLevel]},
+                         @{@"CPU Type" : [self cpuType]},
+                         @{@"Disk" : [self disk]},
+                         @{@"Network State" : [self networkStateFromStatebar]}];
+    
+    NSMutableArray *mutDevices = [[NSMutableArray alloc] initWithArray:devices];
+    NSString *ssid = [self currentWifiSSID];
+    if (ssid) {
+        [mutDevices insertObject:@{@"SSID" : ssid} atIndex:7];
+    }
+    return mutDevices;
 }
 
 #pragma mark - CPU
@@ -290,7 +348,6 @@ NSString * const LLAppHelperFPSKey = @"LLAppHelperFPSKey";
     if (!_cpuTypeString) {
         _cpuTypeString = [self stringFromCpuType:[self getCpuType]];
     }
-    
     return _cpuTypeString;
 }
 
@@ -345,7 +402,7 @@ NSString * const LLAppHelperFPSKey = @"LLAppHelperFPSKey";
 }
 
 - (void)postAppHelperDidUpdateAppInfosNotification {
-    [[NSNotificationCenter defaultCenter] postNotificationName:LLAppHelperDidUpdateAppInfosNotificationName object:nil userInfo:@{LLAppHelperCPUKey:@(_cpu),LLAppHelperFPSKey:@(_fps),LLAppHelperMemoryFreeKey:@(_freeMemory),LLAppHelperMemoryUsedKey:@(_usedMemory),LLAppHelperMemoryTotalKey:@(_totalMemory)}];
+    [[NSNotificationCenter defaultCenter] postNotificationName:LLAppHelperDidUpdateAppInfosNotificationName object:[self dynamicInfos] userInfo:@{LLAppHelperCPUKey:@(_cpu),LLAppHelperFPSKey:@(_fps),LLAppHelperMemoryFreeKey:@(_freeMemory),LLAppHelperMemoryUsedKey:@(_usedMemory),LLAppHelperMemoryTotalKey:@(_totalMemory),LLAppHelperDataTrafficKey:[self dataCounter]}];
 }
 
 #pragma mark - FPS
@@ -456,5 +513,46 @@ NSString * const LLAppHelperFPSKey = @"LLAppHelperFPSKey";
     }
     return _networkState;
 }
+
+#pragma mark - DataTraffic
+- (NSArray *)dataCounters
+
+{
+    struct ifaddrs *addrs;
+    const struct ifaddrs *cursor;
+    
+    u_int32_t WiFiSent = 0;
+    u_int32_t WiFiReceived = 0;
+    u_int32_t WWANSent = 0;
+    u_int32_t WWANReceived = 0;
+    
+    if (getifaddrs(&addrs) == 0) {
+        cursor = addrs;
+        while (cursor != NULL) {
+            if (cursor->ifa_addr->sa_family == AF_LINK) {
+                // en0 is WiFi, pdp_ip0 is WWAN.
+                NSString *name = [NSString stringWithFormat:@"%s",cursor->ifa_name];
+                if ([name hasPrefix:@"en0"]) {
+                    const struct if_data *ifa_data = (struct if_data *)cursor->ifa_data;
+                    if (ifa_data != NULL) {
+                        WiFiSent += ifa_data->ifi_obytes;
+                        WiFiReceived += ifa_data->ifi_ibytes;
+                    }
+                } else if ([name hasPrefix:@"pdp_ip0"]) {
+                    const struct if_data *ifa_data = (struct if_data *)cursor->ifa_data;
+                    if(ifa_data != NULL) {
+                        WWANSent += ifa_data->ifi_obytes;
+                        WWANReceived += ifa_data->ifi_ibytes;
+                    }
+                }
+            }
+            cursor = cursor->ifa_next;
+        }
+        freeifaddrs(addrs);
+    }
+    
+    return @[[NSNumber numberWithUnsignedLongLong:WiFiSent],[NSNumber numberWithUnsignedLongLong:WiFiReceived],[NSNumber numberWithUnsignedLongLong:WWANSent],[NSNumber numberWithUnsignedLongLong:WWANReceived]];
+}
+
 
 @end

--- a/LLDebugTool/Helper/AppHelper/LLAppHelper.m
+++ b/LLDebugTool/Helper/AppHelper/LLAppHelper.m
@@ -134,10 +134,16 @@ NSString * const LLAppHelperTotalDataTrafficKey = @"LLAppHelperTotalDataTrafficK
 }
 
 - (void)updateRequestDataTraffic:(unsigned long long)requestDataTraffic responseDataTraffic:(unsigned long long)responseDataTraffic {
-    @synchronized (self) {
-        _requestDataTraffic += requestDataTraffic;
-        _responseDataTraffic += responseDataTraffic;
-        _totalDataTraffic = _requestDataTraffic + _responseDataTraffic;
+    if ([[NSThread currentThread] isMainThread]) {
+        dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+            [self updateRequestDataTraffic:requestDataTraffic responseDataTraffic:responseDataTraffic];
+        });
+    } else {
+        @synchronized (self) {
+            _requestDataTraffic += requestDataTraffic;
+            _responseDataTraffic += responseDataTraffic;
+            _totalDataTraffic = _requestDataTraffic + _responseDataTraffic;
+        }
     }
 }
 

--- a/LLDebugTool/Helper/NetworkHelper/LLNetworkModel.h
+++ b/LLDebugTool/Helper/NetworkHelper/LLNetworkModel.h
@@ -28,6 +28,7 @@
  */
 @interface LLNetworkModel : LLStorageModel
 
+#pragma mark - Request
 /**
  Network request start date.
  */
@@ -44,14 +45,30 @@
 @property (nonatomic , copy , nullable) NSString *method;
 
 /**
- Network request mine type.
- */
-@property (nonatomic , copy , nullable) NSString *mineType;
-
-/**
  Network request request body.
  */
 @property (nonatomic , copy , nullable) NSString *requestBody;
+
+/**
+ Network request header.
+ */
+@property (nonatomic , strong , nullable) NSDictionary <NSString *,NSString *>*headerFields;
+
+/**
+ Cookies.
+ */
+@property (nonatomic , strong , readonly , nullable) NSDictionary <NSString *, NSString *>*cookies;
+
+#pragma mark - Response
+/**
+ Http response protocol.
+ */
+@property (nonatomic , copy , nullable) NSString *stateLine;
+
+/**
+ Network request mine type.
+ */
+@property (nonatomic , copy , nullable) NSString *mineType;
 
 /**
  Network request status code.
@@ -79,15 +96,11 @@
 @property (nonatomic , strong , nullable) NSError *error;
 
 /**
- Network request header.
- */
-@property (nonatomic , strong , nullable) NSDictionary <NSString *,NSString *>*headerFields;
-
-/**
  Network response header.
  */
 @property (nonatomic , strong , nullable) NSDictionary <NSString *,NSString *>*responseHeaderFields;
 
+#pragma mark - Data traffic
 /**
  Upload data traffic.
  */
@@ -104,20 +117,21 @@
 @property (nonatomic , copy , readonly , nullable) NSString *totalDataTraffic;
 
 /**
- Upload data traffic value.
+ Request line + headers + body.
  */
 @property (nonatomic , assign , readonly) unsigned long long requestDataTrafficValue;
 
 /**
- Download data traffic value.
+ Response state line + headers + response object.
  */
 @property (nonatomic , assign , readonly) unsigned long long responseDataTrafficValue;
 
 /**
- Total data traffic value.
+ Request data traffic + response data traffic.
  */
 @property (nonatomic , assign , readonly) unsigned long long totalDataTrafficValue;
 
+#pragma mark - Other
 /**
  Network request identity.
  */

--- a/LLDebugTool/Helper/NetworkHelper/LLNetworkModel.h
+++ b/LLDebugTool/Helper/NetworkHelper/LLNetworkModel.h
@@ -86,6 +86,11 @@
 @property (nonatomic , assign) BOOL isImage;
 
 /**
+ Is gif or not.
+ */
+@property (nonatomic , assign) BOOL isGif;
+
+/**
  Network request used duration.
  */
 @property (nonatomic , copy , nonnull) NSString *totalDuration;

--- a/LLDebugTool/Helper/NetworkHelper/LLNetworkModel.h
+++ b/LLDebugTool/Helper/NetworkHelper/LLNetworkModel.h
@@ -88,14 +88,34 @@
  */
 @property (nonatomic , strong , nullable) NSDictionary <NSString *,NSString *>*responseHeaderFields;
 
+/**
+ Upload data traffic.
+ */
 @property (nonatomic , copy , readonly , nullable) NSString *requestDataTraffic;
 
+/**
+ Download data traffic.
+ */
 @property (nonatomic , copy , readonly , nullable) NSString *responseDataTraffic;
 
+/**
+ Total data traffic.
+ */
 @property (nonatomic , copy , readonly , nullable) NSString *totalDataTraffic;
 
+/**
+ Upload data traffic value.
+ */
 @property (nonatomic , assign , readonly) unsigned long long requestDataTrafficValue;
+
+/**
+ Download data traffic value.
+ */
 @property (nonatomic , assign , readonly) unsigned long long responseDataTrafficValue;
+
+/**
+ Total data traffic value.
+ */
 @property (nonatomic , assign , readonly) unsigned long long totalDataTrafficValue;
 
 /**

--- a/LLDebugTool/Helper/NetworkHelper/LLNetworkModel.h
+++ b/LLDebugTool/Helper/NetworkHelper/LLNetworkModel.h
@@ -84,6 +84,21 @@
 @property (nonatomic , strong , nullable) NSDictionary <NSString *,NSString *>*headerFields;
 
 /**
+ Network response header.
+ */
+@property (nonatomic , strong , nullable) NSDictionary <NSString *,NSString *>*responseHeaderFields;
+
+@property (nonatomic , copy , readonly , nullable) NSString *requestDataTraffic;
+
+@property (nonatomic , copy , readonly , nullable) NSString *responseDataTraffic;
+
+@property (nonatomic , copy , readonly , nullable) NSString *totalDataTraffic;
+
+@property (nonatomic , assign , readonly) unsigned long long requestDataTrafficValue;
+@property (nonatomic , assign , readonly) unsigned long long responseDataTrafficValue;
+@property (nonatomic , assign , readonly) unsigned long long totalDataTrafficValue;
+
+/**
  Network request identity.
  */
 @property (nonatomic , copy , readonly , nonnull) NSString *identity;

--- a/LLDebugTool/Helper/NetworkHelper/LLNetworkModel.h
+++ b/LLDebugTool/Helper/NetworkHelper/LLNetworkModel.h
@@ -66,9 +66,9 @@
 @property (nonatomic , copy , nullable) NSString *stateLine;
 
 /**
- Network request mine type.
+ Network request mime type.
  */
-@property (nonatomic , copy , nullable) NSString *mineType;
+@property (nonatomic , copy , nullable) NSString *mimeType;
 
 /**
  Network request status code.

--- a/LLDebugTool/Helper/NetworkHelper/LLNetworkModel.h
+++ b/LLDebugTool/Helper/NetworkHelper/LLNetworkModel.h
@@ -91,6 +91,16 @@
 @property (nonatomic , assign) BOOL isGif;
 
 /**
+ Is html or not.
+ */
+@property (nonatomic , assign , readonly) BOOL isHTML;
+
+/**
+ Is txt or not.
+ */
+@property (nonatomic , assign , readonly) BOOL isTXT;
+
+/**
  Network request used duration.
  */
 @property (nonatomic , copy , nonnull) NSString *totalDuration;

--- a/LLDebugTool/Helper/NetworkHelper/LLNetworkModel.m
+++ b/LLDebugTool/Helper/NetworkHelper/LLNetworkModel.m
@@ -155,7 +155,7 @@
 }
 
 - (NSString *)description {
-    return [NSString stringWithFormat:@"[LLNetworkModel] \n url:%@,\n startDate:%@,\n method:%@,\n mineType:%@,\n requestBody:%@,\n statusCode:%@,\n header:%@,\n response:%@,\n totalDuration:%@,\n dataTraffic:%@,\n error:%@,\n identity:%@",self.url.absoluteString,self.startDate,self.method,self.mineType,self.requestBody,self.statusCode,self.headerString,self.responseString,self.totalDuration,self.totalDataTraffic,self.error.localizedDescription,self.identity];
+    return [NSString stringWithFormat:@"[LLNetworkModel] \n url:%@,\n startDate:%@,\n method:%@,\n mimeType:%@,\n requestBody:%@,\n statusCode:%@,\n header:%@,\n response:%@,\n totalDuration:%@,\n dataTraffic:%@,\n error:%@,\n identity:%@",self.url.absoluteString,self.startDate,self.method,self.mimeType,self.requestBody,self.statusCode,self.headerString,self.responseString,self.totalDuration,self.totalDataTraffic,self.error.localizedDescription,self.identity];
 }
 
 #pragma mark - Primary

--- a/LLDebugTool/Helper/NetworkHelper/LLNetworkModel.m
+++ b/LLDebugTool/Helper/NetworkHelper/LLNetworkModel.m
@@ -62,6 +62,13 @@
     }
 }
 
+- (void)setMimeType:(NSString *)mimeType {
+    if (![_mimeType isEqualToString:mimeType]) {
+        _mimeType = [mimeType copy];
+        [self dealWithMimeType:mimeType];
+    }
+}
+
 - (NSString *)headerString {
     if (!_headerString) {
         _headerString = [LLTool convertJSONStringFromDictionary:self.headerFields];
@@ -159,6 +166,39 @@
 }
 
 #pragma mark - Primary
+- (void)dealWithMimeType:(NSString *)mimeType {
+    // See http://svn.apache.org/repos/asf/httpd/httpd/trunk/docs/conf/mime.types
+    NSString *mime = mimeType.lowercaseString;
+    if ([mime isEqualToString:@"image/jpeg"] || [mime isEqualToString:@"image/png"] || [mime isEqualToString:@"image/jpg"]) {
+        _isImage = YES;
+    } else if ([mime isEqualToString:@"image/gif"]) {
+        _isImage = YES;
+        _isGif = YES;
+    } else if ([mime isEqualToString:@"text/html"]) {
+        _isHTML = YES;
+    } else if ([mime isEqualToString:@"text/plain"]) {
+        _isTXT = YES;
+    } else if ([mime isEqualToString:@"video/quicktime"]) {
+        
+    } else if ([mime isEqualToString:@"video/x-msvideo"]) {
+        
+    } else if ([mime isEqualToString:@"audio/mpeg"]) {
+        
+    } else if ([mime isEqualToString:@"audio/x-wav"]) {
+        
+    } else if ([mime isEqualToString:@"application/json"]) {
+        
+    } else if ([mime isEqualToString:@"application/pdf"]) {
+        
+    } else if ([mime isEqualToString:@"application/vnd.ms-excel"]) {
+        
+    } else if ([mime isEqualToString:@"application/vnd.ms-powerpoint"]) {
+        
+    } else if ([mime isEqualToString:@"application/msword"]) {
+        
+    }
+}
+
 - (unsigned long long)dataTrafficLength:(NSString *)string {
     if (string == nil || ![string isKindOfClass:[NSString class]] || string.length == 0) {
         return 0;

--- a/LLDebugTool/Helper/NetworkHelper/LLURLProtocol.m
+++ b/LLDebugTool/Helper/NetworkHelper/LLURLProtocol.m
@@ -26,6 +26,7 @@
 #import "LLNetworkModel.h"
 #import "LLConfig.h"
 #import "LLTool.h"
+#import "LLAppHelper.h"
 
 static NSString *const HTTPHandledIdentifier = @"HttpHandleIdentifier";
 
@@ -114,6 +115,7 @@ static NSString *const HTTPHandledIdentifier = @"HttpHandleIdentifier";
     model.totalDuration = [NSString stringWithFormat:@"%fs",[[NSDate date] timeIntervalSinceDate:self.startDate]];
     model.error = self.error;
     [[LLStorageManager sharedManager] saveModel:model complete:nil];
+    [[LLAppHelper sharedHelper] updateRequestDataTraffic:model.requestDataTrafficValue responseDataTraffic:model.responseDataTrafficValue];
 }
 
 #pragma mark - NSURLSessionDelegate

--- a/LLDebugTool/Helper/NetworkHelper/LLURLProtocol.m
+++ b/LLDebugTool/Helper/NetworkHelper/LLURLProtocol.m
@@ -113,6 +113,9 @@ static NSString *const HTTPHandledIdentifier = @"HttpHandleIdentifier";
     NSString *absoluteString = self.request.URL.absoluteString.lowercaseString;
     if ([absoluteString hasSuffix:@".jpg"] || [absoluteString hasSuffix:@".jpeg"] || [absoluteString hasSuffix:@".png"] || [absoluteString hasSuffix:@".gif"]) {
         model.isImage = YES;
+        if ([absoluteString hasSuffix:@".gif"]) {
+            model.isGif = YES;
+        }
     }
     model.totalDuration = [NSString stringWithFormat:@"%fs",[[NSDate date] timeIntervalSinceDate:self.startDate]];
     model.error = self.error;

--- a/LLDebugTool/Helper/NetworkHelper/LLURLProtocol.m
+++ b/LLDebugTool/Helper/NetworkHelper/LLURLProtocol.m
@@ -106,7 +106,7 @@ static NSString *const HTTPHandledIdentifier = @"HttpHandleIdentifier";
     model.mineType = self.response.MIMEType;
     model.statusCode = [NSString stringWithFormat:@"%d",(int)httpResponse.statusCode];
     model.responseData = self.data;
-    model.responseHeaderFields = httpResponse.allHeaderFields;
+    model.responseHeaderFields = [httpResponse.allHeaderFields mutableCopy];
     if (self.response.MIMEType) {
         model.isImage = [self.response.MIMEType rangeOfString:@"image"].location != NSNotFound;
     }

--- a/LLDebugTool/Helper/NetworkHelper/LLURLProtocol.m
+++ b/LLDebugTool/Helper/NetworkHelper/LLURLProtocol.m
@@ -103,7 +103,7 @@ static NSString *const HTTPHandledIdentifier = @"HttpHandleIdentifier";
     // Response
     NSHTTPURLResponse* httpResponse = (NSHTTPURLResponse*)self.response;
     model.stateLine = httpResponse.stateLine;
-    model.mineType = self.response.MIMEType;
+    model.mimeType = self.response.MIMEType;
     model.statusCode = [NSString stringWithFormat:@"%d",(int)httpResponse.statusCode];
     model.responseData = self.data;
     model.responseHeaderFields = [httpResponse.allHeaderFields mutableCopy];

--- a/LLDebugTool/Helper/NetworkHelper/LLURLProtocol.m
+++ b/LLDebugTool/Helper/NetworkHelper/LLURLProtocol.m
@@ -88,19 +88,22 @@ static NSString *const HTTPHandledIdentifier = @"HttpHandleIdentifier";
     self.dataTask           = nil;
     LLNetworkModel *model = [[LLNetworkModel alloc] init];
     model.startDate = [LLTool stringFromDate:self.startDate];
+    // Request
     model.url = self.request.URL;
     model.method = self.request.HTTPMethod;
-    model.headerFields = self.request.allHTTPHeaderFields;
-    model.mineType = self.response.MIMEType;
+    model.headerFields = [self.request.allHTTPHeaderFields mutableCopy];
     if (self.request.HTTPBody) {
         model.requestBody = [LLTool convertJSONStringFromData:self.request.HTTPBody];
     } else if (self.request.HTTPBodyStream) {
         NSData* data = [self dataFromInputStream:self.request.HTTPBodyStream];
         model.requestBody = [LLTool convertJSONStringFromData:data];
     }
+    // Response
     NSHTTPURLResponse* httpResponse = (NSHTTPURLResponse*)self.response;
+    model.mineType = self.response.MIMEType;
     model.statusCode = [NSString stringWithFormat:@"%d",(int)httpResponse.statusCode];
     model.responseData = self.data;
+    model.responseHeaderFields = httpResponse.allHeaderFields;
     if (self.response.MIMEType) {
         model.isImage = [self.response.MIMEType rangeOfString:@"image"].location != NSNotFound;
     }

--- a/LLDebugTool/Helper/NetworkHelper/LLURLProtocol.m
+++ b/LLDebugTool/Helper/NetworkHelper/LLURLProtocol.m
@@ -27,6 +27,7 @@
 #import "LLConfig.h"
 #import "LLTool.h"
 #import "LLAppHelper.h"
+#import "NSHTTPURLResponse+LL_Utils.h"
 
 static NSString *const HTTPHandledIdentifier = @"HttpHandleIdentifier";
 
@@ -101,6 +102,7 @@ static NSString *const HTTPHandledIdentifier = @"HttpHandleIdentifier";
     }
     // Response
     NSHTTPURLResponse* httpResponse = (NSHTTPURLResponse*)self.response;
+    model.stateLine = httpResponse.stateLine;
     model.mineType = self.response.MIMEType;
     model.statusCode = [NSString stringWithFormat:@"%d",(int)httpResponse.statusCode];
     model.responseData = self.data;

--- a/LLDebugTool/Helper/NetworkHelper/LLURLProtocol.m
+++ b/LLDebugTool/Helper/NetworkHelper/LLURLProtocol.m
@@ -104,19 +104,17 @@ static NSString *const HTTPHandledIdentifier = @"HttpHandleIdentifier";
     NSHTTPURLResponse* httpResponse = (NSHTTPURLResponse*)self.response;
     model.stateLine = httpResponse.stateLine;
     model.mimeType = self.response.MIMEType;
-    model.statusCode = [NSString stringWithFormat:@"%d",(int)httpResponse.statusCode];
-    model.responseData = self.data;
-    model.responseHeaderFields = [httpResponse.allHeaderFields mutableCopy];
-    if (self.response.MIMEType) {
-        model.isImage = [self.response.MIMEType rangeOfString:@"image"].location != NSNotFound;
-    }
-    NSString *absoluteString = self.request.URL.absoluteString.lowercaseString;
-    if ([absoluteString hasSuffix:@".jpg"] || [absoluteString hasSuffix:@".jpeg"] || [absoluteString hasSuffix:@".png"] || [absoluteString hasSuffix:@".gif"]) {
-        model.isImage = YES;
-        if ([absoluteString hasSuffix:@".gif"]) {
+    if (model.mimeType.length == 0) {
+        NSString *absoluteString = self.request.URL.absoluteString.lowercaseString;
+        if ([absoluteString hasSuffix:@".jpg"] || [absoluteString hasSuffix:@".jpeg"] || [absoluteString hasSuffix:@".png"]) {
+            model.isImage = YES;
+        } else if ([absoluteString hasSuffix:@".gif"]) {
             model.isGif = YES;
         }
     }
+    model.statusCode = [NSString stringWithFormat:@"%d",(int)httpResponse.statusCode];
+    model.responseData = self.data;
+    model.responseHeaderFields = [httpResponse.allHeaderFields mutableCopy];
     model.totalDuration = [NSString stringWithFormat:@"%fs",[[NSDate date] timeIntervalSinceDate:self.startDate]];
     model.error = self.error;
     [[LLStorageManager sharedManager] saveModel:model complete:nil];

--- a/LLDebugTool/UserInterface/Categories/NSHTTPURLResponse/NSHTTPURLResponse+LL_Utils.h
+++ b/LLDebugTool/UserInterface/Categories/NSHTTPURLResponse/NSHTTPURLResponse+LL_Utils.h
@@ -1,0 +1,33 @@
+//
+//  NSHTTPURLResponse+LL_Utils.h
+//
+//  Copyright (c) 2018 LLBaseFoundation Software Foundation (https://github.com/HDB-Li/LLDebugTool)
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+
+#import <Foundation/Foundation.h>
+
+@interface NSHTTPURLResponse (LL_Utils)
+
+/**
+ State line in NSHTTPURLResponse.
+ */
+- (NSString *_Nullable)stateLine;
+
+@end

--- a/LLDebugTool/UserInterface/Categories/NSHTTPURLResponse/NSHTTPURLResponse+LL_Utils.m
+++ b/LLDebugTool/UserInterface/Categories/NSHTTPURLResponse/NSHTTPURLResponse+LL_Utils.m
@@ -1,0 +1,58 @@
+//
+//  NSHTTPURLResponse+LL_Utils.m
+//
+//  Copyright (c) 2018 LLBaseFoundation Software Foundation (https://github.com/HDB-Li/LLDebugTool)
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+
+#import "NSHTTPURLResponse+LL_Utils.h"
+#import <dlfcn.h>
+
+typedef CFHTTPMessageRef (*LLHTTPURLResponseGetHTTPProtocol)(CFURLRef response);
+
+@implementation NSHTTPURLResponse (LL_Utils)
+
+- (NSString *_Nullable)stateLine {
+    
+    NSString *stateLine = nil;
+    
+    NSString *functionName = @"CFURLResponseGetHTTPResponse";
+    LLHTTPURLResponseGetHTTPProtocol getMessage = dlsym(RTLD_DEFAULT, [functionName UTF8String]);
+    SEL selector = NSSelectorFromString(@"_CFURLResponse");
+    if ([self respondsToSelector:selector] && NULL != getMessage) {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Warc-performSelector-leaks"
+        CFTypeRef cfResponse = CFBridgingRetain([self performSelector:selector]);
+#pragma clang diagnostic pop
+        if (NULL != cfResponse) {
+            CFHTTPMessageRef messageRef = getMessage(cfResponse);
+            if (NULL != messageRef) {
+                CFStringRef stateLineRef = CFHTTPMessageCopyResponseStatusLine(messageRef);
+                if (NULL != stateLineRef) {
+                    stateLine = (__bridge NSString *)stateLineRef;
+                    CFRelease(stateLineRef);
+                }
+            }
+            CFRelease(cfResponse);
+        }
+    }
+    return stateLine;
+}
+
+@end

--- a/LLDebugTool/UserInterface/Categories/NSObject/NSObject+LL_Utils.h
+++ b/LLDebugTool/UserInterface/Categories/NSObject/NSObject+LL_Utils.h
@@ -1,5 +1,5 @@
 //
-//  NSObject+LLBase_Utils.h
+//  NSObject+LL_Utils.h
 //
 //  Copyright (c) 2018 LLBaseFoundation Software Foundation (https://github.com/HDB-Li/LLDebugTool)
 //

--- a/LLDebugTool/UserInterface/Categories/NSObject/NSObject+LL_Utils.m
+++ b/LLDebugTool/UserInterface/Categories/NSObject/NSObject+LL_Utils.m
@@ -1,5 +1,5 @@
 //
-//  NSObject+LLBase_Utils.m
+//  NSObject+LL_Utils.m
 //
 //  Copyright (c) 2018 LLBaseFoundation Software Foundation (https://github.com/HDB-Li/LLBaseFoundation)
 //

--- a/LLDebugTool/UserInterface/Categories/NSString/NSString+LL_Utils.h
+++ b/LLDebugTool/UserInterface/Categories/NSString/NSString+LL_Utils.h
@@ -22,6 +22,7 @@
 //  SOFTWARE.
 
 #import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
 
 @interface NSString (LL_Utils)
 
@@ -29,6 +30,8 @@
 - (NSArray *)LL_jsonArray;
 
 - (unsigned long long)byteLength;
+
+- (CGFloat)heightWithAttributes:(NSDictionary *)attributes maxWidth:(CGFloat)maxWidth minHeight:(CGFloat)minHeight;
 
 @end
 

--- a/LLDebugTool/UserInterface/Categories/NSString/NSString+LL_Utils.h
+++ b/LLDebugTool/UserInterface/Categories/NSString/NSString+LL_Utils.h
@@ -28,6 +28,8 @@
 - (NSDictionary *)LL_jsonDictionary;
 - (NSArray *)LL_jsonArray;
 
+- (unsigned long long)byteLength;
+
 @end
 
 @interface NSDictionary (LL_Utils)

--- a/LLDebugTool/UserInterface/Categories/NSString/NSString+LL_Utils.m
+++ b/LLDebugTool/UserInterface/Categories/NSString/NSString+LL_Utils.m
@@ -71,6 +71,16 @@
     return (length + 1) / 2;
 }
 
+- (CGFloat)heightWithAttributes:(NSDictionary *)attributes maxWidth:(CGFloat)maxWidth minHeight:(CGFloat)minHeight {
+    if (self.length == 0) {
+        return 0;
+    }
+    CGRect rect = [self boundingRectWithSize:CGSizeMake(maxWidth, CGFLOAT_MAX) options:NSStringDrawingUsesLineFragmentOrigin attributes:attributes context:nil];
+    // Sometime, it's a little small.
+    rect = CGRectMake(rect.origin.x, rect.origin.y, rect.size.width + 4, rect.size.height + 4);
+    return rect.size.height > minHeight ? rect.size.height : minHeight;
+}
+
 @end
 
 @implementation NSDictionary (LL_Utils)

--- a/LLDebugTool/UserInterface/Categories/NSString/NSString+LL_Utils.m
+++ b/LLDebugTool/UserInterface/Categories/NSString/NSString+LL_Utils.m
@@ -53,6 +53,24 @@
     return nil;
 }
 
+- (unsigned long long)byteLength {
+    if (self.length == 0) {
+        return 0;
+    }
+    unsigned long long length = 0;
+    char *p = (char *)[self cStringUsingEncoding:NSUnicodeStringEncoding];
+    for (NSInteger i = 0 ; i < [self lengthOfBytesUsingEncoding:NSUnicodeStringEncoding] ; i++)
+    {
+        if (*p) {
+            p++;
+            length++;
+        } else {
+            p++;
+        }
+    }
+    return (length + 1) / 2;
+}
+
 @end
 
 @implementation NSDictionary (LL_Utils)

--- a/LLDebugTool/UserInterface/Categories/UIImage/UIImage+LL_Utils.h
+++ b/LLDebugTool/UserInterface/Categories/UIImage/UIImage+LL_Utils.h
@@ -30,6 +30,6 @@
 /**
  This part is from SDWebImage.
  */
-+ (nullable UIImage *)LL_imageWithGIFData:(NSData *)data;
++ (nullable UIImage *)LL_imageWithGIFData:(NSData *_Nullable)data;
 
 @end

--- a/LLDebugTool/UserInterface/Categories/UIImage/UIImage+LL_Utils.h
+++ b/LLDebugTool/UserInterface/Categories/UIImage/UIImage+LL_Utils.h
@@ -27,4 +27,9 @@
 
 + (nullable UIImage *)LL_imageNamed:(NSString *_Nonnull)name;
 
+/**
+ This part is from SDWebImage.
+ */
++ (nullable UIImage *)LL_imageWithGIFData:(NSData *)data;
+
 @end

--- a/LLDebugTool/UserInterface/Categories/UIImage/UIImage+LL_Utils.m
+++ b/LLDebugTool/UserInterface/Categories/UIImage/UIImage+LL_Utils.m
@@ -67,11 +67,11 @@
     NSDictionary *frameProperties = (__bridge NSDictionary *)cfFrameProperties;
     NSDictionary *gifProperties = frameProperties[(NSString *)kCGImagePropertyGIFDictionary];
     NSNumber *delayTimeUnclampedProp = gifProperties[(NSString *)kCGImagePropertyGIFUnclampedDelayTime];
-    if (delayTimeUnclampedProp) {
+    if (delayTimeUnclampedProp != nil) {
         frameDuration = [delayTimeUnclampedProp floatValue];
     } else {
         NSNumber *delayTimeProp = gifProperties[(NSString *)kCGImagePropertyGIFDelayTime];
-        if (delayTimeProp) {
+        if (delayTimeProp != nil) {
             frameDuration = [delayTimeProp floatValue];
         }
     }

--- a/LLDebugTool/UserInterface/Categories/UIImage/UIImage+LL_Utils.m
+++ b/LLDebugTool/UserInterface/Categories/UIImage/UIImage+LL_Utils.m
@@ -30,4 +30,57 @@
     return [UIImage imageNamed:name inBundle:[LLConfig sharedConfig].imageBundle compatibleWithTraitCollection:nil];
 }
 
++ (nullable UIImage *)LL_imageWithGIFData:(NSData *)data {
+    if (!data) {
+        return nil;
+    }
+    
+    CGImageSourceRef source = CGImageSourceCreateWithData((__bridge CFDataRef)data, NULL);
+    size_t count = CGImageSourceGetCount(source);
+    UIImage *animatedImage;
+    if (count <= 1) {
+        animatedImage = [[UIImage alloc] initWithData:data];
+    } else {
+        NSMutableArray *images = [NSMutableArray array];
+        NSTimeInterval duration = 0.0f;
+        for (size_t i = 0; i < count; i++) {
+            CGImageRef image = CGImageSourceCreateImageAtIndex(source, i, NULL);
+            if (!image) {
+                continue;
+            }
+            duration += [self LL_frameDurationAtIndex:i source:source];
+            [images addObject:[UIImage imageWithCGImage:image scale:[UIScreen mainScreen].scale orientation:UIImageOrientationUp]];
+            CGImageRelease(image);
+        }
+        if (!duration) {
+            duration = (1.0f / 10.0f) * count;
+        }
+        animatedImage = [UIImage animatedImageWithImages:images duration:duration];
+    }
+    CFRelease(source);
+    return animatedImage;
+}
+
++ (float)LL_frameDurationAtIndex:(NSUInteger)index source:(CGImageSourceRef)source {
+    float frameDuration = 0.1f;
+    CFDictionaryRef cfFrameProperties = CGImageSourceCopyPropertiesAtIndex(source, index, nil);
+    NSDictionary *frameProperties = (__bridge NSDictionary *)cfFrameProperties;
+    NSDictionary *gifProperties = frameProperties[(NSString *)kCGImagePropertyGIFDictionary];
+    NSNumber *delayTimeUnclampedProp = gifProperties[(NSString *)kCGImagePropertyGIFUnclampedDelayTime];
+    if (delayTimeUnclampedProp) {
+        frameDuration = [delayTimeUnclampedProp floatValue];
+    } else {
+        NSNumber *delayTimeProp = gifProperties[(NSString *)kCGImagePropertyGIFDelayTime];
+        if (delayTimeProp) {
+            frameDuration = [delayTimeProp floatValue];
+        }
+    }
+    if (frameDuration < 0.011f) {
+        frameDuration = 0.100f;
+    }
+    CFRelease(cfFrameProperties);
+    return frameDuration;
+}
+
+
 @end

--- a/LLDebugTool/UserInterface/Others/LLSubTitleTableViewCell.h
+++ b/LLDebugTool/UserInterface/Others/LLSubTitleTableViewCell.h
@@ -27,6 +27,6 @@
 
 @property (weak, nonatomic) IBOutlet UILabel *titleLabel;
 
-@property (weak, nonatomic) IBOutlet UILabel *contentLabel;
+@property (weak, nonatomic) IBOutlet UITextView *contentLabel;
 
 @end

--- a/LLDebugTool/UserInterface/Others/LLSubTitleTableViewCell.h
+++ b/LLDebugTool/UserInterface/Others/LLSubTitleTableViewCell.h
@@ -27,6 +27,6 @@
 
 @property (weak, nonatomic) IBOutlet UILabel *titleLabel;
 
-@property (weak, nonatomic) IBOutlet UITextView *contentLabel;
+@property (copy , nonatomic , nullable) NSString *contentText;
 
 @end

--- a/LLDebugTool/UserInterface/Others/LLSubTitleTableViewCell.m
+++ b/LLDebugTool/UserInterface/Others/LLSubTitleTableViewCell.m
@@ -24,11 +24,25 @@
 #import "LLSubTitleTableViewCell.h"
 #import "LLConfig.h"
 
+@interface LLSubTitleTableViewCell ()
+
+@property (weak, nonatomic) IBOutlet UITextView *contentLabel;
+
+@end
+
 @implementation LLSubTitleTableViewCell
 
 - (void)awakeFromNib {
     [super awakeFromNib];
     [self initial];
+}
+
+- (void)setContentText:(NSString *)contentText {
+    if (![_contentText isEqualToString:contentText]) {
+        _contentText = [contentText copy];
+        self.contentLabel.scrollEnabled = NO;
+        self.contentLabel.text = _contentText;
+    }
 }
 
 #pragma mark - Primary
@@ -43,10 +57,14 @@
 
 - (void)layoutSubviews {
     [super layoutSubviews];
-    if (self.contentLabel.frame.size.height >= 300) {
-        self.contentLabel.scrollEnabled = YES;
-    } else {
-        self.contentLabel.scrollEnabled = NO;
+    if (self.contentLabel.constraints.count == 3) {
+        NSLayoutConstraint *systemHeightCons = self.contentLabel.constraints[1];
+        NSLayoutConstraint *heightCons = self.contentLabel.constraints[2];
+        if (systemHeightCons.constant > heightCons.constant) {
+            self.contentLabel.scrollEnabled = YES;
+        } else {
+            self.contentLabel.scrollEnabled = NO;
+        }
     }
 }
 

--- a/LLDebugTool/UserInterface/Others/LLSubTitleTableViewCell.m
+++ b/LLDebugTool/UserInterface/Others/LLSubTitleTableViewCell.m
@@ -22,6 +22,7 @@
 //  SOFTWARE.
 
 #import "LLSubTitleTableViewCell.h"
+#import "LLConfig.h"
 
 @implementation LLSubTitleTableViewCell
 
@@ -34,6 +35,19 @@
 - (void)initial {
     self.titleLabel.font = [UIFont boldSystemFontOfSize:19];
     self.titleLabel.adjustsFontSizeToFitWidth = YES;
+    self.contentLabel.backgroundColor = nil;
+    if (LLCONFIG_CUSTOM_COLOR) {
+        self.contentLabel.textColor = LLCONFIG_TEXT_COLOR;
+    }
+}
+
+- (void)layoutSubviews {
+    [super layoutSubviews];
+    if (self.contentLabel.frame.size.height >= 300) {
+        self.contentLabel.scrollEnabled = YES;
+    } else {
+        self.contentLabel.scrollEnabled = NO;
+    }
 }
 
 @end

--- a/LLDebugTool/UserInterface/Others/LLSubTitleTableViewCell.xib
+++ b/LLDebugTool/UserInterface/Others/LLSubTitleTableViewCell.xib
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14109" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13196" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13173"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -39,7 +39,7 @@
                     <constraint firstItem="CRw-Tx-vUd" firstAttribute="top" secondItem="fZF-Si-7NL" secondAttribute="bottom" id="dHk-dt-rOG"/>
                     <constraint firstItem="fZF-Si-7NL" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="15" id="lf2-yx-5KP"/>
                     <constraint firstAttribute="trailing" secondItem="CRw-Tx-vUd" secondAttribute="trailing" constant="15" id="tm3-Rj-EcC"/>
-                    <constraint firstAttribute="bottom" secondItem="CRw-Tx-vUd" secondAttribute="bottom" constant="5" id="x72-W2-pXj"/>
+                    <constraint firstAttribute="bottom" secondItem="CRw-Tx-vUd" secondAttribute="bottom" priority="750" constant="5" id="x72-W2-pXj"/>
                     <constraint firstAttribute="trailing" secondItem="fZF-Si-7NL" secondAttribute="trailing" constant="15" id="x9x-PG-KeH"/>
                     <constraint firstItem="CRw-Tx-vUd" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="15" id="xQa-7J-Qqf"/>
                 </constraints>

--- a/LLDebugTool/UserInterface/Others/LLSubTitleTableViewCell.xib
+++ b/LLDebugTool/UserInterface/Others/LLSubTitleTableViewCell.xib
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13196" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14113" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13173"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -18,7 +18,7 @@
                 <rect key="frame" x="0.0" y="0.0" width="320" height="65.5"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fZF-Si-7NL">
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="characterWrap" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fZF-Si-7NL">
                         <rect key="frame" x="15" y="10" width="290" height="25"/>
                         <constraints>
                             <constraint firstAttribute="height" constant="25" id="1KI-ye-BlL"/>

--- a/LLDebugTool/UserInterface/Others/LLSubTitleTableViewCell.xib
+++ b/LLDebugTool/UserInterface/Others/LLSubTitleTableViewCell.xib
@@ -27,25 +27,29 @@
                         <nil key="textColor"/>
                         <nil key="highlightedColor"/>
                     </label>
-                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="CRw-Tx-vUd">
-                        <rect key="frame" x="15" y="35" width="290" height="25"/>
+                    <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" scrollEnabled="NO" editable="NO" textAlignment="natural" selectable="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ZrM-wH-xaf">
+                        <rect key="frame" x="15" y="40" width="290" height="20.5"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <constraints>
+                            <constraint firstAttribute="height" relation="lessThanOrEqual" priority="750" constant="300" id="Muh-r2-csR"/>
+                        </constraints>
+                        <string key="text">Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Nam liber te conscient to factor tum poen legum odioque civiuda.</string>
                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                        <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                        <nil key="highlightedColor"/>
-                    </label>
+                        <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
+                    </textView>
                 </subviews>
                 <constraints>
+                    <constraint firstItem="ZrM-wH-xaf" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="15" id="ADW-6M-zEX"/>
                     <constraint firstItem="fZF-Si-7NL" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="10" id="EiV-pD-bJy"/>
-                    <constraint firstItem="CRw-Tx-vUd" firstAttribute="top" secondItem="fZF-Si-7NL" secondAttribute="bottom" id="dHk-dt-rOG"/>
+                    <constraint firstAttribute="trailing" secondItem="ZrM-wH-xaf" secondAttribute="trailing" constant="15" id="IfJ-rN-scw"/>
+                    <constraint firstAttribute="bottom" secondItem="ZrM-wH-xaf" secondAttribute="bottom" constant="5" id="Joq-2K-kdu"/>
+                    <constraint firstItem="ZrM-wH-xaf" firstAttribute="top" secondItem="fZF-Si-7NL" secondAttribute="bottom" constant="5" id="Vei-tA-Ims"/>
                     <constraint firstItem="fZF-Si-7NL" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="15" id="lf2-yx-5KP"/>
-                    <constraint firstAttribute="trailing" secondItem="CRw-Tx-vUd" secondAttribute="trailing" constant="15" id="tm3-Rj-EcC"/>
-                    <constraint firstAttribute="bottom" secondItem="CRw-Tx-vUd" secondAttribute="bottom" priority="750" constant="5" id="x72-W2-pXj"/>
                     <constraint firstAttribute="trailing" secondItem="fZF-Si-7NL" secondAttribute="trailing" constant="15" id="x9x-PG-KeH"/>
-                    <constraint firstItem="CRw-Tx-vUd" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="15" id="xQa-7J-Qqf"/>
                 </constraints>
             </tableViewCellContentView>
             <connections>
-                <outlet property="contentLabel" destination="CRw-Tx-vUd" id="YMu-ce-wGj"/>
+                <outlet property="contentLabel" destination="ZrM-wH-xaf" id="yw9-Sx-jfV"/>
                 <outlet property="titleLabel" destination="fZF-Si-7NL" id="DII-mv-vOR"/>
             </connections>
             <point key="canvasLocation" x="135" y="66"/>

--- a/LLDebugTool/UserInterface/Others/ScreenShotView/LLScreenshotToolbar.h
+++ b/LLDebugTool/UserInterface/Others/ScreenShotView/LLScreenshotToolbar.h
@@ -29,7 +29,7 @@
 
 @protocol LLScreenshotToolbarDelegate <NSObject>
 
-- (void)LLScreenshotToolbar:(LLScreenshotToolbar *_Nonnull)toolBar didSelectedAction:(LLScreenshotAction)action selectorModel:(LLScreenshotSelectorModel *_Nonnull)selectorModel;
+- (void)LLScreenshotToolbar:(LLScreenshotToolbar *_Nonnull)toolBar didSelectedAction:(LLScreenshotAction)action selectorModel:(LLScreenshotSelectorModel *_Nullable)selectorModel;
 
 @end
 

--- a/LLDebugTool/UserInterface/Sections/AppInfo/LLAppInfoVC.m
+++ b/LLDebugTool/UserInterface/Sections/AppInfo/LLAppInfoVC.m
@@ -74,16 +74,9 @@ static NSString *const kLLAppInfoVCHeaderID = @"HeaderID";
 }
 
 - (void)didReceiveLLAppHelperDidUpdateAppInfosNotification:(NSNotification *)notifi {
-    NSDictionary *userInfo = notifi.userInfo;
-    CGFloat cpu = [userInfo[LLAppHelperCPUKey] floatValue];
-    CGFloat usedMemory = [userInfo[LLAppHelperMemoryUsedKey] floatValue];
-    CGFloat freeMemory = [userInfo[LLAppHelperMemoryFreeKey] floatValue];
-    CGFloat fps = [userInfo[LLAppHelperFPSKey] floatValue];
-    
-    NSArray *dynamic = [[NSArray alloc] initWithObjects:@{@"CPU Usage" : [NSString stringWithFormat:@"%.2f%%",cpu]},@{@"Memory Usage" : [NSString stringWithFormat:@"Used:%@, Free:%@",[NSByteCountFormatter stringFromByteCount:usedMemory countStyle:NSByteCountFormatterCountStyleMemory],[NSByteCountFormatter stringFromByteCount:freeMemory countStyle:NSByteCountFormatterCountStyleMemory]]},@{@"FPS" : [NSString stringWithFormat:@"%ld FPS",(long)fps]}, nil];
+    NSArray *dynamic = notifi.object;
     [self.dataArray replaceObjectAtIndex:0 withObject:dynamic];
     [self.tableView reloadSections:[NSIndexSet indexSetWithIndex:0] withRowAnimation:UITableViewRowAnimationNone];
-
 }
 
 #pragma mark - Table view data source

--- a/LLDebugTool/UserInterface/Sections/AppInfo/LLAppInfoVC.m
+++ b/LLDebugTool/UserInterface/Sections/AppInfo/LLAppInfoVC.m
@@ -95,7 +95,7 @@ static NSString *const kLLAppInfoVCHeaderID = @"HeaderID";
         cell = [[LLBaseTableViewCell alloc] initWithStyle:UITableViewCellStyleValue1 reuseIdentifier:kLLAppInfoVCCellID];
         cell.detailTextLabel.adjustsFontSizeToFitWidth = YES;
         cell.detailTextLabel.lineBreakMode = NSLineBreakByTruncatingMiddle;
-        cell.detailTextLabel.minimumScaleFactor = 0.7;
+        cell.detailTextLabel.minimumScaleFactor = 0.5;
         cell.selectionStyle = UITableViewCellSelectionStyleNone;
     }
     NSDictionary *dic = self.dataArray[indexPath.section][indexPath.row];

--- a/LLDebugTool/UserInterface/Sections/Crash/LLCrashCell.xib
+++ b/LLDebugTool/UserInterface/Sections/Crash/LLCrashCell.xib
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14109" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13196" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13173"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -15,17 +15,17 @@
             <rect key="frame" x="0.0" y="0.0" width="320" height="110"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
-                <rect key="frame" x="0.0" y="0.0" width="286" height="109.5"/>
+                <rect key="frame" x="0.0" y="0.0" width="287" height="109.5"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="*** -[__NSArrayM insertObject:atIndex:]: object cannot be nil" textAlignment="natural" lineBreakMode="characterWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="iEy-V6-PQ0">
-                        <rect key="frame" x="16" y="10" width="254" height="44.5"/>
+                        <rect key="frame" x="16" y="10" width="255" height="44.5"/>
                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                         <nil key="textColor"/>
                         <nil key="highlightedColor"/>
                     </label>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Name" textAlignment="natural" lineBreakMode="characterWrap" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="u3i-GP-Otw">
-                        <rect key="frame" x="16" y="59.5" width="254" height="20"/>
+                        <rect key="frame" x="16" y="59.5" width="255" height="20"/>
                         <constraints>
                             <constraint firstAttribute="height" constant="20" id="Ve9-m1-ZCT"/>
                         </constraints>
@@ -45,7 +45,7 @@
                 <constraints>
                     <constraint firstItem="iEy-V6-PQ0" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="16" id="5qI-HO-OM9"/>
                     <constraint firstItem="u3i-GP-Otw" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="16" id="HY6-Zb-8pZ"/>
-                    <constraint firstAttribute="bottom" secondItem="0xW-RG-sJg" secondAttribute="bottom" constant="10" id="JaY-wr-qTe"/>
+                    <constraint firstAttribute="bottom" secondItem="0xW-RG-sJg" secondAttribute="bottom" priority="750" constant="10" id="JaY-wr-qTe"/>
                     <constraint firstAttribute="trailing" secondItem="u3i-GP-Otw" secondAttribute="trailing" constant="16" id="KD4-2Z-baq"/>
                     <constraint firstItem="u3i-GP-Otw" firstAttribute="top" secondItem="iEy-V6-PQ0" secondAttribute="bottom" constant="5" id="U3v-zp-xe1"/>
                     <constraint firstItem="0xW-RG-sJg" firstAttribute="top" secondItem="u3i-GP-Otw" secondAttribute="bottom" constant="5" id="XRj-aO-HvH"/>

--- a/LLDebugTool/UserInterface/Sections/Log/LLLogCell.xib
+++ b/LLDebugTool/UserInterface/Sections/Log/LLLogCell.xib
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14109" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13196" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13173"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -20,25 +20,25 @@
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="254" text="File" textAlignment="natural" lineBreakMode="characterWrap" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ZLi-dU-POK">
-                        <rect key="frame" x="16" y="11" width="21.5" height="16"/>
+                        <rect key="frame" x="8" y="8" width="21.5" height="16"/>
                         <fontDescription key="fontDescription" type="system" pointSize="13"/>
                         <nil key="textColor"/>
                         <nil key="highlightedColor"/>
                     </label>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="Func" textAlignment="natural" lineBreakMode="characterWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="PLn-iM-HW1">
-                        <rect key="frame" x="16" y="32" width="30" height="16"/>
+                        <rect key="frame" x="8" y="29" width="30" height="16"/>
                         <fontDescription key="fontDescription" type="system" pointSize="13"/>
                         <nil key="textColor"/>
                         <nil key="highlightedColor"/>
                     </label>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="253" text="Date" textAlignment="natural" lineBreakMode="characterWrap" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Oxb-xi-r9v">
-                        <rect key="frame" x="16" y="53" width="29" height="16"/>
+                        <rect key="frame" x="8" y="50" width="29" height="16"/>
                         <fontDescription key="fontDescription" type="system" pointSize="13"/>
                         <nil key="textColor"/>
                         <nil key="highlightedColor"/>
                     </label>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Message" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Dav-qA-0QV">
-                        <rect key="frame" x="16" y="74" width="288" height="29"/>
+                        <rect key="frame" x="8" y="71" width="304" height="34.5"/>
                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                         <nil key="textColor"/>
                         <nil key="highlightedColor"/>
@@ -46,7 +46,7 @@
                 </subviews>
                 <constraints>
                     <constraint firstItem="PLn-iM-HW1" firstAttribute="top" secondItem="ZLi-dU-POK" secondAttribute="bottom" constant="5" id="3fN-Jg-ULG"/>
-                    <constraint firstItem="Dav-qA-0QV" firstAttribute="bottom" secondItem="H2p-sc-9uM" secondAttribute="bottomMargin" id="Cxh-TF-VkA"/>
+                    <constraint firstItem="Dav-qA-0QV" firstAttribute="bottom" secondItem="H2p-sc-9uM" secondAttribute="bottomMargin" priority="750" id="Cxh-TF-VkA"/>
                     <constraint firstItem="ZLi-dU-POK" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="topMargin" id="Kmr-wR-fiC"/>
                     <constraint firstItem="Oxb-xi-r9v" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leadingMargin" id="QOC-XB-Pq1"/>
                     <constraint firstAttribute="trailingMargin" relation="greaterThanOrEqual" secondItem="PLn-iM-HW1" secondAttribute="trailing" id="S8j-Oy-Sla"/>

--- a/LLDebugTool/UserInterface/Sections/Log/LLLogContentVC.m
+++ b/LLDebugTool/UserInterface/Sections/Log/LLLogContentVC.m
@@ -53,7 +53,7 @@ static NSString *const kLogContentCellID = @"LogContentCellID";
     LLSubTitleTableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:kLogContentCellID];
     cell.selectionStyle = UITableViewCellSelectionStyleNone;
     cell.titleLabel.text = self.titleArray[indexPath.row];
-    cell.contentLabel.text = content;
+    cell.contentText = content;
     return cell;
 }
 

--- a/LLDebugTool/UserInterface/Sections/Network/LLNetworkCell.m
+++ b/LLDebugTool/UserInterface/Sections/Network/LLNetworkCell.m
@@ -47,7 +47,7 @@
     if (_model != model) {
         _model = model;
         self.hostLabel.text = _model.url.host;
-        self.paramLabel.text = _model.url.path.length ? _model.url.path : @"None";
+        self.paramLabel.text = _model.url.path;
         self.dateLabel.text = [_model.startDate substringFromIndex:11];
     }
 }

--- a/LLDebugTool/UserInterface/Sections/Network/LLNetworkCell.xib
+++ b/LLDebugTool/UserInterface/Sections/Network/LLNetworkCell.xib
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14109" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13196" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13173"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -15,7 +15,7 @@
             <rect key="frame" x="0.0" y="0.0" width="320" height="65"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
-                <rect key="frame" x="0.0" y="0.0" width="286" height="64.5"/>
+                <rect key="frame" x="0.0" y="0.0" width="287" height="64.5"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2Qv-Uc-Dex">
@@ -28,7 +28,7 @@
                         <nil key="highlightedColor"/>
                     </label>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="12:00:58" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vq5-wt-kdt">
-                        <rect key="frame" x="221" y="14.5" width="65" height="17"/>
+                        <rect key="frame" x="222" y="14.5" width="65" height="17"/>
                         <constraints>
                             <constraint firstAttribute="width" constant="65" id="pSJ-xX-qjg"/>
                         </constraints>
@@ -37,7 +37,7 @@
                         <nil key="highlightedColor"/>
                     </label>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="l3z-I9-Mqm">
-                        <rect key="frame" x="15" y="35" width="271" height="19.5"/>
+                        <rect key="frame" x="15" y="35" width="272" height="19.5"/>
                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                         <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <nil key="highlightedColor"/>
@@ -45,7 +45,7 @@
                 </subviews>
                 <constraints>
                     <constraint firstItem="vq5-wt-kdt" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="2Qv-Uc-Dex" secondAttribute="trailing" constant="5" id="6ID-RT-o1K"/>
-                    <constraint firstAttribute="bottom" secondItem="l3z-I9-Mqm" secondAttribute="bottom" constant="10" id="Bip-k5-LIs"/>
+                    <constraint firstAttribute="bottom" secondItem="l3z-I9-Mqm" secondAttribute="bottom" priority="750" constant="10" id="Bip-k5-LIs"/>
                     <constraint firstItem="2Qv-Uc-Dex" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="10" id="CIX-Wi-ATs"/>
                     <constraint firstItem="l3z-I9-Mqm" firstAttribute="top" secondItem="2Qv-Uc-Dex" secondAttribute="bottom" id="Fdc-KQ-OJi"/>
                     <constraint firstAttribute="trailing" secondItem="l3z-I9-Mqm" secondAttribute="trailing" id="J7U-Gg-Bgw"/>

--- a/LLDebugTool/UserInterface/Sections/Network/LLNetworkContentVC.m
+++ b/LLDebugTool/UserInterface/Sections/Network/LLNetworkContentVC.m
@@ -137,6 +137,10 @@ static NSString *const kNetworkImageCellID = @"NetworkImageCellID";
             [self.titleArray addObject:@"Total Duration"];
             [self.contentArray addObject:self.model.totalDuration];
         }
+        if (self.model.totalDataTraffic) {
+            [self.titleArray addObject:@"Data Traffic"];
+            [self.contentArray addObject:[NSString stringWithFormat:@"%@  (Upload : %@ / Download : %@)",self.model.totalDataTraffic,self.model.requestDataTraffic,self.model.responseDataTraffic]];
+        }
         
         [self.titleArray addObject:@"Request Body"];
         [self.contentArray addObject:self.model.requestBody ?: @"Null"];

--- a/LLDebugTool/UserInterface/Sections/Network/LLNetworkContentVC.m
+++ b/LLDebugTool/UserInterface/Sections/Network/LLNetworkContentVC.m
@@ -26,6 +26,7 @@
 #import "LLNetworkImageCell.h"
 #import "LLConfig.h"
 #import "LLTool.h"
+#import "UIImage+LL_Utils.h"
 
 static NSString *const kNetworkContentCellID = @"NetworkContentCellID";
 static NSString *const kNetworkImageCellID = @"NetworkImageCellID";
@@ -57,7 +58,11 @@ static NSString *const kNetworkImageCellID = @"NetworkImageCellID";
     // Config Image
     if ([obj isKindOfClass:[NSData class]] && self.model.isImage) {
         LLNetworkImageCell *cell = [tableView dequeueReusableCellWithIdentifier:kNetworkImageCellID forIndexPath:indexPath];
-        [cell setUpImage:[UIImage imageWithData:obj]];
+        if ([self.model.url.absoluteString.lowercaseString hasSuffix:@"gif"]) {
+            [cell setUpImage:[UIImage LL_imageWithGIFData:obj]];
+        } else {
+            [cell setUpImage:[UIImage imageWithData:obj]];
+        }
         return cell;
     }
     if ([obj isKindOfClass:[NSData class]]) {
@@ -76,7 +81,12 @@ static NSString *const kNetworkImageCellID = @"NetworkImageCellID";
     if ([self.canCopyArray containsObject:title]) {
         id obj = self.contentArray[indexPath.row];
         if ([obj isKindOfClass:[NSData class]] && self.model.isImage) {
-            UIImage *image = [UIImage imageWithData:obj];
+            UIImage *image = nil;
+            if ([self.model.url.absoluteString.lowercaseString hasSuffix:@"gif"]) {
+                image = [UIImage LL_imageWithGIFData:obj];
+            } else {
+                image = [UIImage imageWithData:obj];
+            }
             if ([image isKindOfClass:[UIImage class]]) {
                 [UIPasteboard generalPasteboard].image = image;
                 [self toastMessage:[NSString stringWithFormat:@"Copy \"%@\" Success",title]];

--- a/LLDebugTool/UserInterface/Sections/Network/LLNetworkContentVC.m
+++ b/LLDebugTool/UserInterface/Sections/Network/LLNetworkContentVC.m
@@ -77,14 +77,17 @@ static NSString *const kNetworkImageCellID = @"NetworkImageCellID";
         id obj = self.contentArray[indexPath.row];
         if ([obj isKindOfClass:[NSData class]] && self.model.isImage) {
             UIImage *image = [UIImage imageWithData:obj];
-            [UIPasteboard generalPasteboard].image = image;
-        } else {
+            if ([image isKindOfClass:[UIImage class]]) {
+                [UIPasteboard generalPasteboard].image = image;
+                [self toastMessage:[NSString stringWithFormat:@"Copy \"%@\" Success",title]];
+            }
+        } else if ([obj isKindOfClass:[NSData class]] || [obj isKindOfClass:[NSString class]]) {
             if ([obj isKindOfClass:[NSData class]]) {
                 obj = [self convertDataToHexStr:obj];
             }
             [UIPasteboard generalPasteboard].string = obj;
+            [self toastMessage:[NSString stringWithFormat:@"Copy \"%@\" Success",title]];
         }
-        [self toastMessage:[NSString stringWithFormat:@"Copy \"%@\" Success",title]];
     }
 
 }

--- a/LLDebugTool/UserInterface/Sections/Network/LLNetworkContentVC.m
+++ b/LLDebugTool/UserInterface/Sections/Network/LLNetworkContentVC.m
@@ -138,9 +138,9 @@ static NSString *const kNetworkImageCellID = @"NetworkImageCellID";
             }
             [self.contentArray addObject:string];
         }
-        if (self.model.mineType) {
-            [self.titleArray addObject:@"Mine Type"];
-            [self.contentArray addObject:self.model.mineType];
+        if (self.model.mimeType) {
+            [self.titleArray addObject:@"Mime Type"];
+            [self.contentArray addObject:self.model.mimeType];
         }
         if (self.model.startDate) {
             [self.titleArray addObject:@"Start Date"];

--- a/LLDebugTool/UserInterface/Sections/Network/LLNetworkContentVC.m
+++ b/LLDebugTool/UserInterface/Sections/Network/LLNetworkContentVC.m
@@ -58,7 +58,7 @@ static NSString *const kNetworkImageCellID = @"NetworkImageCellID";
     // Config Image
     if ([obj isKindOfClass:[NSData class]] && self.model.isImage) {
         LLNetworkImageCell *cell = [tableView dequeueReusableCellWithIdentifier:kNetworkImageCellID forIndexPath:indexPath];
-        if ([self.model.url.absoluteString.lowercaseString hasSuffix:@"gif"]) {
+        if (self.model.isGif) {
             [cell setUpImage:[UIImage LL_imageWithGIFData:obj]];
         } else {
             [cell setUpImage:[UIImage imageWithData:obj]];
@@ -82,7 +82,7 @@ static NSString *const kNetworkImageCellID = @"NetworkImageCellID";
         id obj = self.contentArray[indexPath.row];
         if ([obj isKindOfClass:[NSData class]] && self.model.isImage) {
             UIImage *image = nil;
-            if ([self.model.url.absoluteString.lowercaseString hasSuffix:@"gif"]) {
+            if (self.model.isGif) {
                 image = [UIImage LL_imageWithGIFData:obj];
             } else {
                 image = [UIImage imageWithData:obj];

--- a/LLDebugTool/UserInterface/Sections/Network/LLNetworkContentVC.m
+++ b/LLDebugTool/UserInterface/Sections/Network/LLNetworkContentVC.m
@@ -142,7 +142,7 @@ static NSString *const kNetworkImageCellID = @"NetworkImageCellID";
         }
         if (self.model.totalDataTraffic) {
             [self.titleArray addObject:@"Data Traffic"];
-            [self.contentArray addObject:[NSString stringWithFormat:@"%@  (Upload : %@ / Download : %@)",self.model.totalDataTraffic,self.model.requestDataTraffic,self.model.responseDataTraffic]];
+            [self.contentArray addObject:[NSString stringWithFormat:@"%@ (%@↑ / %@↓)",self.model.totalDataTraffic,self.model.requestDataTraffic,self.model.responseDataTraffic]];
         }
         
         [self.titleArray addObject:@"Request Body"];

--- a/LLDebugTool/UserInterface/Sections/Network/LLNetworkContentVC.m
+++ b/LLDebugTool/UserInterface/Sections/Network/LLNetworkContentVC.m
@@ -72,7 +72,7 @@ static NSString *const kNetworkImageCellID = @"NetworkImageCellID";
     LLSubTitleTableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:kNetworkContentCellID];
     cell.selectionStyle = UITableViewCellSelectionStyleNone;
     cell.titleLabel.text = self.titleArray[indexPath.row];
-    cell.contentLabel.text = obj;
+    cell.contentText = obj;
     return cell;
 }
 
@@ -99,7 +99,6 @@ static NSString *const kNetworkImageCellID = @"NetworkImageCellID";
             [self toastMessage:[NSString stringWithFormat:@"Copy \"%@\" Success",title]];
         }
     }
-
 }
 
 #pragma mark - Primary

--- a/LLDebugTool/UserInterface/Sections/Network/LLNetworkImageCell.m
+++ b/LLDebugTool/UserInterface/Sections/Network/LLNetworkImageCell.m
@@ -57,8 +57,6 @@
 - (void)initial {
     self.selectionStyle = UITableViewCellSelectionStyleNone;
     self.titleLabel.font = [UIFont boldSystemFontOfSize:19];
-    [self setNeedsLayout];
-    [self layoutIfNeeded];
 }
 
 @end

--- a/LLDebugTool/UserInterface/Sections/Network/LLNetworkImageCell.xib
+++ b/LLDebugTool/UserInterface/Sections/Network/LLNetworkImageCell.xib
@@ -1,43 +1,45 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14109" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13196" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
-        <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13173"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" rowHeight="77" id="KGk-i7-Jjw" customClass="LLNetworkImageCell">
-            <rect key="frame" x="0.0" y="0.0" width="320" height="77"/>
+        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" id="KGk-i7-Jjw" customClass="LLNetworkImageCell">
+            <rect key="frame" x="0.0" y="0.0" width="320" height="85.5"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
-                <rect key="frame" x="0.0" y="0.0" width="320" height="76.5"/>
+                <rect key="frame" x="0.0" y="0.0" width="320" height="85"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="rsF-zm-cfn">
-                        <rect key="frame" x="0.0" y="33.5" width="320" height="43.5"/>
-                        <constraints>
-                            <constraint firstAttribute="height" constant="43.5" id="gkG-4b-Lej"/>
-                        </constraints>
-                    </imageView>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Response Body" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="VcH-oi-99A">
-                        <rect key="frame" x="16" y="11" width="120" height="17.5"/>
+                        <rect key="frame" x="15" y="10" width="120" height="25"/>
+                        <constraints>
+                            <constraint firstAttribute="height" constant="25" id="SzS-p9-sn6"/>
+                        </constraints>
                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                         <nil key="textColor"/>
                         <nil key="highlightedColor"/>
                     </label>
+                    <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="rsF-zm-cfn">
+                        <rect key="frame" x="0.0" y="40" width="320" height="45"/>
+                        <constraints>
+                            <constraint firstAttribute="height" constant="45" id="gkG-4b-Lej"/>
+                        </constraints>
+                    </imageView>
                 </subviews>
                 <constraints>
-                    <constraint firstItem="rsF-zm-cfn" firstAttribute="top" secondItem="VcH-oi-99A" secondAttribute="bottom" constant="5" id="3eG-MN-QVb"/>
-                    <constraint firstItem="VcH-oi-99A" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="topMargin" id="Lyv-dM-aXk"/>
-                    <constraint firstAttribute="bottom" secondItem="rsF-zm-cfn" secondAttribute="bottom" id="hGe-HO-hm7"/>
+                    <constraint firstItem="rsF-zm-cfn" firstAttribute="top" secondItem="VcH-oi-99A" secondAttribute="bottom" constant="5" id="NkR-p2-yhn"/>
+                    <constraint firstItem="VcH-oi-99A" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="10" id="QJA-ug-Ofi"/>
+                    <constraint firstAttribute="bottom" secondItem="rsF-zm-cfn" secondAttribute="bottom" priority="750" id="eTG-er-Zry"/>
                     <constraint firstAttribute="trailing" secondItem="rsF-zm-cfn" secondAttribute="trailing" id="hSf-ZP-XYV"/>
-                    <constraint firstItem="VcH-oi-99A" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leadingMargin" id="jqb-ba-xBJ"/>
+                    <constraint firstItem="VcH-oi-99A" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="15" id="l73-qc-HDT"/>
                     <constraint firstItem="rsF-zm-cfn" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" id="ngz-ja-SeZ"/>
                 </constraints>
             </tableViewCellContentView>
@@ -46,7 +48,7 @@
                 <outlet property="imgViewHeightCons" destination="gkG-4b-Lej" id="Hhu-SI-9FI"/>
                 <outlet property="titleLabel" destination="VcH-oi-99A" id="w6d-WT-3xc"/>
             </connections>
-            <point key="canvasLocation" x="213" y="146.5"/>
+            <point key="canvasLocation" x="213" y="146"/>
         </tableViewCell>
     </objects>
 </document>

--- a/LLDebugTool/UserInterface/Sections/Sandbox/LLSandboxCell.xib
+++ b/LLDebugTool/UserInterface/Sections/Sandbox/LLSandboxCell.xib
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14109" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13196" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13173"/>
         <capability name="Aspect ratio constraints" minToolsVersion="5.1"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -16,11 +16,11 @@
             <rect key="frame" x="0.0" y="0.0" width="320" height="50"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
-                <rect key="frame" x="0.0" y="0.0" width="286" height="49.5"/>
+                <rect key="frame" x="0.0" y="0.0" width="287" height="49.5"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Name" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ajv-Qp-EGh">
-                        <rect key="frame" x="50.5" y="5" width="230.5" height="19.5"/>
+                        <rect key="frame" x="50.5" y="5" width="231.5" height="20.5"/>
                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                         <nil key="textColor"/>
                         <nil key="highlightedColor"/>
@@ -33,7 +33,7 @@
                         </constraints>
                     </imageView>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Date" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="cX5-ja-Ibu">
-                        <rect key="frame" x="50" y="29.5" width="30.5" height="15"/>
+                        <rect key="frame" x="50" y="30.5" width="30.5" height="15"/>
                         <constraints>
                             <constraint firstAttribute="height" constant="15" id="WdU-cw-cUz"/>
                         </constraints>
@@ -42,7 +42,7 @@
                         <nil key="highlightedColor"/>
                     </label>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Size" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ada-eS-SMj">
-                        <rect key="frame" x="253.5" y="29.5" width="27.5" height="15"/>
+                        <rect key="frame" x="254.5" y="30.5" width="27.5" height="15"/>
                         <constraints>
                             <constraint firstAttribute="height" constant="15" id="2h5-d3-eTW"/>
                         </constraints>
@@ -58,7 +58,7 @@
                     <constraint firstAttribute="trailing" secondItem="ajv-Qp-EGh" secondAttribute="trailing" constant="5" id="LXb-rN-ELy"/>
                     <constraint firstItem="ajv-Qp-EGh" firstAttribute="leading" secondItem="sMU-ah-ZUO" secondAttribute="trailing" constant="10" id="OnL-sG-mMr"/>
                     <constraint firstItem="sMU-ah-ZUO" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="10" id="i6q-xd-Myo"/>
-                    <constraint firstAttribute="bottom" secondItem="cX5-ja-Ibu" secondAttribute="bottom" constant="5" id="lZF-M0-kAP"/>
+                    <constraint firstAttribute="bottom" secondItem="cX5-ja-Ibu" secondAttribute="bottom" priority="750" constant="5" id="lZF-M0-kAP"/>
                     <constraint firstItem="Ada-eS-SMj" firstAttribute="top" secondItem="cX5-ja-Ibu" secondAttribute="top" id="r8g-2I-UUi"/>
                     <constraint firstItem="cX5-ja-Ibu" firstAttribute="top" secondItem="ajv-Qp-EGh" secondAttribute="bottom" constant="5" id="sL7-3a-t4W"/>
                     <constraint firstItem="sMU-ah-ZUO" firstAttribute="centerY" secondItem="H2p-sc-9uM" secondAttribute="centerY" id="sef-Uw-dgD"/>

--- a/LLDebugToolDemo.xcodeproj/project.pbxproj
+++ b/LLDebugToolDemo.xcodeproj/project.pbxproj
@@ -1234,7 +1234,7 @@
 				CLANG_ENABLE_OBJC_WEAK = YES;
 				CODE_SIGN_STYLE = Automatic;
 				INFOPLIST_FILE = LLDebugToolDemoUITests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = myCompany.LLDebugToolDemoUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1250,7 +1250,7 @@
 				CLANG_ENABLE_OBJC_WEAK = YES;
 				CODE_SIGN_STYLE = Automatic;
 				INFOPLIST_FILE = LLDebugToolDemoUITests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = myCompany.LLDebugToolDemoUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/LLDebugToolDemo.xcodeproj/project.pbxproj
+++ b/LLDebugToolDemo.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		3687522520C69B22002C6AD9 /* LLScreenshotImageView.m in Sources */ = {isa = PBXBuildFile; fileRef = 3687521D20C69B22002C6AD9 /* LLScreenshotImageView.m */; };
 		368F9DE82119AAF4003F8264 /* LLLogFilterView.m in Sources */ = {isa = PBXBuildFile; fileRef = 36C5BF4E2099897F007A3188 /* LLLogFilterView.m */; };
 		3691A61B20C7E63B00E22192 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 3691A61D20C7E63B00E22192 /* InfoPlist.strings */; };
+		369B258F212E5D6700E771D8 /* NSHTTPURLResponse+LL_Utils.m in Sources */ = {isa = PBXBuildFile; fileRef = 369B258E212E5D6700E771D8 /* NSHTTPURLResponse+LL_Utils.m */; };
 		36A0007720BE863700AE8810 /* NetTool.m in Sources */ = {isa = PBXBuildFile; fileRef = 36A0007620BE863700AE8810 /* NetTool.m */; };
 		36AE43DB20C788E90066EA41 /* LLScreenshotHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 36AE43DA20C788E90066EA41 /* LLScreenshotHelper.m */; };
 		36C5BF782099897F007A3188 /* LLConfig.m in Sources */ = {isa = PBXBuildFile; fileRef = 36C5BEEE2099897F007A3188 /* LLConfig.m */; };
@@ -155,6 +156,8 @@
 		3687521E20C69B22002C6AD9 /* LLScreenshotToolbar.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LLScreenshotToolbar.h; sourceTree = "<group>"; };
 		3691A61C20C7E63B00E22192 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		3691A61E20C7E63D00E22192 /* zh-Hans */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hans"; path = "zh-Hans.lproj/InfoPlist.strings"; sourceTree = "<group>"; };
+		369B258D212E5D6700E771D8 /* NSHTTPURLResponse+LL_Utils.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSHTTPURLResponse+LL_Utils.h"; sourceTree = "<group>"; };
+		369B258E212E5D6700E771D8 /* NSHTTPURLResponse+LL_Utils.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "NSHTTPURLResponse+LL_Utils.m"; sourceTree = "<group>"; };
 		36A0007520BE863700AE8810 /* NetTool.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NetTool.h; sourceTree = "<group>"; };
 		36A0007620BE863700AE8810 /* NetTool.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = NetTool.m; sourceTree = "<group>"; };
 		36AE43D920C788E90066EA41 /* LLScreenshotHelper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LLScreenshotHelper.h; sourceTree = "<group>"; };
@@ -352,6 +355,15 @@
 				3687521620C69B21002C6AD9 /* LLScreenshotBaseOperation.m */,
 			);
 			path = ScreenshotView;
+			sourceTree = "<group>";
+		};
+		369B258C212E5D5B00E771D8 /* NSHTTPURLResponse */ = {
+			isa = PBXGroup;
+			children = (
+				369B258D212E5D6700E771D8 /* NSHTTPURLResponse+LL_Utils.h */,
+				369B258E212E5D6700E771D8 /* NSHTTPURLResponse+LL_Utils.m */,
+			);
+			path = NSHTTPURLResponse;
 			sourceTree = "<group>";
 		};
 		36AE43D820C788E90066EA41 /* ScreenshotHelper */ = {
@@ -636,6 +648,7 @@
 		36C5BF5C2099897F007A3188 /* Categories */ = {
 			isa = PBXGroup;
 			children = (
+				369B258C212E5D5B00E771D8 /* NSHTTPURLResponse */,
 				C41B0A0621205BD700A058CF /* NSObject */,
 				2313EF2C20F5ED160038AD06 /* UIImage */,
 				36C5BF5D2099897F007A3188 /* UIButton */,
@@ -1117,6 +1130,7 @@
 				C43BA80C205AB095006307BE /* AppDelegate.m in Sources */,
 				3687522220C69B22002C6AD9 /* LLScreenshotSelectorModel.m in Sources */,
 				36C5BF8F2099897F007A3188 /* LLCrashContentVC.m in Sources */,
+				369B258F212E5D6700E771D8 /* NSHTTPURLResponse+LL_Utils.m in Sources */,
 				36C5BFA42099897F007A3188 /* LLFilterLabelCell.m in Sources */,
 				36C5BF782099897F007A3188 /* LLConfig.m in Sources */,
 				36C5BFA52099897F007A3188 /* LLFilterLabelModel.m in Sources */,

--- a/LLDebugToolDemo/Info.plist
+++ b/LLDebugToolDemo/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.1.3</string>
+	<string>1.1.4</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>

--- a/README-cn.md
+++ b/README-cn.md
@@ -39,7 +39,9 @@ LLDebugTool是一款针对开发者和测试者的调试工具，它可以帮助
 
 ### 增加网络流量监测功能
 
-现在你可以查看网络请求的流量，虽然他还不是很准确。另外修复了一些已知问题。更多的修改内容可以在[Project 1.1.4](https://github.com/HDB-Li/LLDebugTool/projects/3)中查看。
+现在你可以查看网络请求的流量，虽然他还不是很准确。另外修复了一些已知问题。
+
+更多的修改内容可以在[Project](https://github.com/HDB-Li/LLDebugTool/projects/3)中查看。
 
 #### 新增
 

--- a/README-cn.md
+++ b/README-cn.md
@@ -3,7 +3,7 @@
 </p>
 
 [![Version](https://img.shields.io/badge/IOS-%3E%3D8.0-f07e48.svg)](https://img.shields.io/badge/IOS-%3E%3D8.0-f07e48.svg)
-[![CocoaPods Compatible](https://img.shields.io/badge/pod-v1.1.3-blue.svg)](https://img.shields.io/badge/pod-v1.1.3-blue.svg)
+[![CocoaPods Compatible](https://img.shields.io/badge/pod-v1.1.4-blue.svg)](https://img.shields.io/badge/pod-v1.1.4-blue.svg)
 [![Carthage Compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
 [![Platform](https://img.shields.io/badge/platform-ios-lightgrey.svg)](https://img.shields.io/badge/platform-ios-lightgrey.svg)
 [![License](https://img.shields.io/badge/license-MIT-91bc2b.svg)](https://img.shields.io/badge/license-MIT-91bc2b.svg)
@@ -35,23 +35,28 @@ LLDebugTool是一款针对开发者和测试者的调试工具，它可以帮助
 <img src="https://raw.githubusercontent.com/HDB-Li/HDBImageRepository/master/LLDebugTool/ScreenShot-6.png" width="18%"> </img>
 </div>
 
-## 最近更新 (1.1.3)
+## 最近更新 (1.1.4)
 
-### 重构数据库
+### 增加网络流量监测功能
 
-修复了一些数据库的问题。 现在他能表现的更加友好，你可以通过Mac上的软件查看模型的内容。以后某天，`LLLogHelper` 会单独分离出来，成一个可以在release环境使用的埋点工具。
-
-新的版本会将旧版本的数据库删除，如果你仍有数据需要使用，请在你不需要的时候再更新。
+现在你可以查看网络请求的流量，虽然他还不是很准确。另外修复了一些已知问题。更多的修改内容可以在[Project 1.1.4](https://github.com/HDB-Li/LLDebugTool/projects/3)中查看。
 
 #### 新增
 
-* 增加功能测试和UI测试，虽然它现在什么都没有。
+* 增加流量监控功能，详细内容可以查看 `LLNetworkModel.m`。
 
 #### 更新
 
-* 重构了`LLStorageManager`确保他能够在同步/异步或者主线程/子线程中正常的工作。
-* `DEPRECATED`了一些`LLStorageManager`, `LLTool` 和 `LLAppHelper`中的方法，具体内容可以查看`LLStorageManager.h`, `LLTool.h` 和 `LLAppHelper.h`.
-* 在`LLConfig`中增加一个枚举值，用来控制`LLLogHelper`的log方式。
+* 更新所有XIB文件的约束，用来清除控制台中的约束警告。
+* 用 `UITextView` 代替 `LLSubTitleTableViewCell` 中的 `UILabel` ，用于解决`UILabel`在数据过多的时候显示不全的问题，例如1000行的时候。
+* 用 `MIMETYPE` 来判断一个网络请求数据的类型。
+* 修改 `LLAppHelper.h` ，暴露更多的接口。
+* 修改 `LLStorageManager`，重写了SQL语句。
+
+#### 其他
+
+* 现在可以展示GIF图片了。
+* 修复一些bug。
 
 ## 我能用LLDebugTool做什么?
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,9 @@ Choose LLDebugTool for your next project, or migrate over your existing projects
 
 ### Increase network traffic monitoring
 
-Now you can check your network request traffic, although it is not very accurate. Other some known problems have been fixed. More changes can be viewed in [Project 1.1.4](https://github.com/HDB-Li/LLDebugTool/projects/3).
+Now you can check your network request traffic, although it is not very accurate. 
+
+Other some known problems have been fixed. More changes can be viewed in [Project](https://github.com/HDB-Li/LLDebugTool/projects/3).
 
 #### Add
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 </p>
 
 [![Version](https://img.shields.io/badge/IOS-%3E%3D8.0-f07e48.svg)](https://img.shields.io/badge/IOS-%3E%3D8.0-f07e48.svg)
-[![CocoaPods Compatible](https://img.shields.io/badge/pod-v1.1.3-blue.svg)](https://img.shields.io/badge/pod-v1.1.3-blue.svg)
+[![CocoaPods Compatible](https://img.shields.io/badge/pod-v1.1.4-blue.svg)](https://img.shields.io/badge/pod-v1.1.4-blue.svg)
 [![Carthage Compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
 [![Platform](https://img.shields.io/badge/platform-ios-lightgrey.svg)](https://img.shields.io/badge/platform-ios-lightgrey.svg)
 [![License](https://img.shields.io/badge/license-MIT-91bc2b.svg)](https://img.shields.io/badge/license-MIT-91bc2b.svg)
@@ -35,23 +35,28 @@ Choose LLDebugTool for your next project, or migrate over your existing projects
 <img src="https://raw.githubusercontent.com/HDB-Li/HDBImageRepository/master/LLDebugTool/ScreenShot-6.png" width="18%"> </img>
 </div>
 
-## Recent updates (1.1.3)
+## Recent updates (1.1.4)
 
-### Refactory database
+### Increase network traffic monitoring
 
-Fix some bugs operation in database. It looks more friendlier now, you can watch model's description in Mac software. Someday, `LLLogHelper` will be separated into an online event-tracking tool used in release environment.
-
-The new version will delete the old version of the table in database, if you need the old data, please upgrade when you don't need it.
+Now you can check your network request traffic, although it is not very accurate. Other some known problems have been fixed. More changes can be viewed in [Project 1.1.4](https://github.com/HDB-Li/LLDebugTool/projects/3).
 
 #### Add
 
-* Add UnitTests and UITests, Even now there's nothing.
+* Add data traffic function, details can see `LLNetworkModel.m`.
 
 #### Update
 
-* Refactory `LLStorageManager` to make sure it will work well in synchronous and asynchronous or main thread and child thread.
-* `DEPRECATED` some method in `LLStorageManager`, `LLTool` and `LLAppHelper`, More infomations please see`LLStorageManager.h`, `LLTool.h` and `LLAppHelper.h`.
-* Add a enumeration values in `LLConfig` to control `LLLogHelper`'s log style.
+* Update the constraints in all XIB files, remove constraint warnings from the console.
+* Use `UITextView` replace `UILabel` in `LLSubTitleTableViewCell`, used to solve the problem that `UILabel` does not show when there is too much data, such as 1000 lines.
+* Use `MIMETYPE` to judge the type of a network response.
+* Update `LLAppHelper.h`, expose more interfaces.
+* Update `LLStorageManager`, rewritten SQL statements.
+
+#### Extra
+
+* Now we can display GIF images.
+* Fix some bugs.
         
 ## What can you do with LLDebugTool?
 


### PR DESCRIPTION
### Increase network traffic monitoring

Now you can check your network request traffic, although it is not very accurate. Other some known problems have been fixed. More changes can be viewed in [Project 1.1.4](https://github.com/HDB-Li/LLDebugTool/projects/3).

#### Add

* Add data traffic function, details can see `LLNetworkModel.m`.

#### Update

* Update the constraints in all XIB files, remove constraint warnings from the console.
* Use `UITextView` replace `UILabel` in `LLSubTitleTableViewCell`, used to solve the problem that `UILabel` does not show when there is too much data, such as 1000 lines.
* Use `MIMETYPE` to judge the type of a network response.
* Update `LLAppHelper.h`, expose more interfaces.
* Update `LLStorageManager`, rewritten SQL statements.

#### Extra

* Now we can display GIF images.
* Fix some bugs.